### PR TITLE
Expand billing workflow with taxes and new management sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+build/
+dist/
+*.sqlite3
+*.db
+media/
+staticfiles/
+.DS_Store

--- a/core/admin.py
+++ b/core/admin.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from django.contrib import admin
+
+from .models import (
+    Budget,
+    AccountingRecord,
+    Client,
+    CurrentAccountMovement,
+    Expense,
+    Invoice,
+    Material,
+    OrderPhoto,
+    ProductionOrder,
+    ProductionOrderItem,
+    Remittance,
+    Supplier,
+    UserProfile,
+)
+
+
+class ProductionOrderItemInline(admin.TabularInline):
+    model = ProductionOrderItem
+    extra = 0
+
+
+@admin.register(ProductionOrder)
+class ProductionOrderAdmin(admin.ModelAdmin):
+    inlines = [ProductionOrderItemInline]
+    list_display = ("order_number", "client", "order_date", "status")
+    list_filter = ("status", "order_date")
+    search_fields = ("order_number", "client__name")
+
+
+@admin.register(Client)
+class ClientAdmin(admin.ModelAdmin):
+    list_display = ("name", "service_line", "contact_name", "phone")
+    search_fields = ("name", "service_line", "contact_name")
+
+
+@admin.register(Supplier)
+class SupplierAdmin(admin.ModelAdmin):
+    list_display = ("name", "contact_name", "phone")
+    search_fields = ("name", "contact_name")
+
+
+@admin.register(Material)
+class MaterialAdmin(admin.ModelAdmin):
+    list_display = ("name",)
+
+
+@admin.register(OrderPhoto)
+class OrderPhotoAdmin(admin.ModelAdmin):
+    list_display = ("order", "uploaded_by", "created_at")
+    list_filter = ("materials",)
+
+
+@admin.register(Budget)
+class BudgetAdmin(admin.ModelAdmin):
+    list_display = ("title", "client", "date", "total_amount")
+    list_filter = ("date",)
+    search_fields = ("title", "client__name")
+
+
+@admin.register(Invoice)
+class InvoiceAdmin(admin.ModelAdmin):
+    list_display = (
+        "number",
+        "invoice_type",
+        "date",
+        "gross_amount",
+        "iva_amount",
+        "additional_tax_amount",
+        "amount",
+    )
+    list_filter = ("invoice_type", "date", "iva_rate", "additional_tax_type")
+    search_fields = ("number", "client__name", "supplier__name")
+
+
+@admin.register(Expense)
+class ExpenseAdmin(admin.ModelAdmin):
+    list_display = ("category", "date", "amount")
+    list_filter = ("category", "date")
+
+
+@admin.register(Remittance)
+class RemittanceAdmin(admin.ModelAdmin):
+    list_display = ("number", "date", "client", "order")
+    search_fields = ("number", "client__name", "order__order_number")
+    list_filter = ("date",)
+
+
+@admin.register(CurrentAccountMovement)
+class CurrentAccountMovementAdmin(admin.ModelAdmin):
+    list_display = ("movement_type", "date", "client", "supplier", "amount")
+    list_filter = ("movement_type", "date")
+    search_fields = ("client__name", "supplier__name", "concept")
+
+
+@admin.register(AccountingRecord)
+class AccountingRecordAdmin(admin.ModelAdmin):
+    list_display = ("record_type", "date", "description", "debit", "credit")
+    list_filter = ("record_type", "date")
+    search_fields = ("description", "client__name", "supplier__name", "document_number")
+
+
+@admin.register(UserProfile)
+class UserProfileAdmin(admin.ModelAdmin):
+    list_display = ("user", "role")
+    list_filter = ("role",)
+    search_fields = ("user__username", "user__first_name", "user__last_name")

--- a/core/apps.py
+++ b/core/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"
+
+    def ready(self) -> None:  # pragma: no cover - import side effects
+        import core.signals  # noqa: F401

--- a/core/forms.py
+++ b/core/forms.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Iterable
+
+from django import forms
+from django.forms import formset_factory
+
+from .models import (
+    AccountingRecord,
+    Budget,
+    Client,
+    CurrentAccountMovement,
+    Expense,
+    Invoice,
+    Material,
+    ORDER_ITEM_PRESETS,
+    ProductionOrder,
+    Remittance,
+    Supplier,
+)
+
+
+def _widget_with_class(widget: forms.Widget, css_class: str = "form-control") -> forms.Widget:
+    if isinstance(widget, forms.Select):
+        widget.attrs.setdefault("class", "form-select")
+    elif isinstance(widget, forms.CheckboxSelectMultiple):
+        widget.attrs.setdefault("class", "form-check-input")
+    else:
+        widget.attrs.setdefault("class", css_class)
+    return widget
+
+
+class ClientForm(forms.ModelForm):
+    class Meta:
+        model = Client
+        fields = ["name", "service_line", "contact_name", "email", "phone", "notes"]
+        widgets = {
+            "name": _widget_with_class(forms.TextInput()),
+            "service_line": _widget_with_class(forms.TextInput()),
+            "contact_name": _widget_with_class(forms.TextInput()),
+            "email": _widget_with_class(forms.EmailInput()),
+            "phone": _widget_with_class(forms.TextInput()),
+            "notes": _widget_with_class(forms.Textarea(attrs={"rows": 3})),
+        }
+
+
+class SupplierForm(forms.ModelForm):
+    class Meta:
+        model = Supplier
+        fields = ["name", "contact_name", "email", "phone", "notes"]
+        widgets = {
+            "name": _widget_with_class(forms.TextInput()),
+            "contact_name": _widget_with_class(forms.TextInput()),
+            "email": _widget_with_class(forms.EmailInput()),
+            "phone": _widget_with_class(forms.TextInput()),
+            "notes": _widget_with_class(forms.Textarea(attrs={"rows": 3})),
+        }
+
+
+class ProductionOrderForm(forms.ModelForm):
+    class Meta:
+        model = ProductionOrder
+        fields = [
+            "client",
+            "order_date",
+            "service_line",
+            "internal_code",
+            "bodywork",
+            "contact_name",
+            "email",
+            "phone",
+            "status",
+            "notes",
+        ]
+        widgets = {
+            "client": _widget_with_class(forms.Select()),
+            "order_date": _widget_with_class(forms.DateInput(attrs={"type": "date"})),
+            "service_line": _widget_with_class(forms.TextInput()),
+            "internal_code": _widget_with_class(forms.TextInput()),
+            "bodywork": _widget_with_class(forms.TextInput()),
+            "contact_name": _widget_with_class(forms.TextInput()),
+            "email": _widget_with_class(forms.EmailInput()),
+            "phone": _widget_with_class(forms.TextInput()),
+            "status": _widget_with_class(forms.Select()),
+            "notes": _widget_with_class(forms.Textarea(attrs={"rows": 3})),
+        }
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.fields["client"].required = False
+        if hasattr(self.fields["client"], "empty_label"):
+            self.fields["client"].empty_label = "Seleccioná un cliente (opcional)"
+
+
+class OrderItemForm(forms.Form):
+    preset_key = forms.CharField(widget=forms.HiddenInput())
+    preset_name = forms.CharField(label="Descripción", required=False)
+    detail = forms.CharField(label="Detalle", required=False)
+    colors = forms.CharField(label="Colores", required=False)
+    measure = forms.CharField(label="Medida", required=False)
+    quantity = forms.DecimalField(
+        label="Cant.",
+        required=False,
+        max_digits=10,
+        decimal_places=2,
+        min_value=Decimal("0"),
+    )
+    unit_price = forms.DecimalField(
+        label="Precio",
+        required=False,
+        max_digits=10,
+        decimal_places=2,
+        min_value=Decimal("0"),
+    )
+    total_amount = forms.DecimalField(
+        label="Total",
+        required=False,
+        max_digits=12,
+        decimal_places=2,
+        min_value=Decimal("0"),
+    )
+
+    def clean(self) -> dict[str, object]:
+        cleaned_data = super().clean()
+        quantity = cleaned_data.get("quantity")
+        unit_price = cleaned_data.get("unit_price")
+        total_amount = cleaned_data.get("total_amount")
+        if total_amount is None and quantity is not None and unit_price is not None:
+            cleaned_data["total_amount"] = (quantity * unit_price).quantize(Decimal("0.01"))
+        return cleaned_data
+
+
+OrderItemFormSet = formset_factory(OrderItemForm, extra=0)
+
+
+class BudgetForm(forms.ModelForm):
+    class Meta:
+        model = Budget
+        fields = [
+            "client",
+            "title",
+            "description",
+            "date",
+            "square_meters",
+            "price_per_square_meter",
+            "additional_costs",
+        ]
+        widgets = {
+            "client": _widget_with_class(forms.Select()),
+            "title": _widget_with_class(forms.TextInput()),
+            "description": _widget_with_class(forms.Textarea(attrs={"rows": 3})),
+            "date": _widget_with_class(forms.DateInput(attrs={"type": "date"})),
+            "square_meters": _widget_with_class(forms.NumberInput(attrs={"step": "0.01"})),
+            "price_per_square_meter": _widget_with_class(forms.NumberInput(attrs={"step": "0.01"})),
+            "additional_costs": _widget_with_class(forms.NumberInput(attrs={"step": "0.01"})),
+        }
+
+
+class InvoiceForm(forms.ModelForm):
+    class Meta:
+        model = Invoice
+        fields = [
+            "invoice_type",
+            "number",
+            "date",
+            "client",
+            "supplier",
+            "order",
+            "gross_amount",
+            "iva_rate",
+            "iva_amount",
+            "additional_tax_type",
+            "additional_tax_amount",
+            "amount",
+            "description",
+        ]
+        widgets = {
+            "invoice_type": _widget_with_class(forms.Select()),
+            "number": _widget_with_class(forms.TextInput()),
+            "date": _widget_with_class(forms.DateInput(attrs={"type": "date"})),
+            "client": _widget_with_class(forms.Select()),
+            "supplier": _widget_with_class(forms.Select()),
+            "order": _widget_with_class(forms.Select()),
+            "gross_amount": _widget_with_class(forms.NumberInput(attrs={"step": "0.01"})),
+            "iva_rate": _widget_with_class(forms.Select()),
+            "iva_amount": _widget_with_class(forms.NumberInput(attrs={"step": "0.01", "readonly": True})),
+            "additional_tax_type": _widget_with_class(forms.Select()),
+            "additional_tax_amount": _widget_with_class(forms.NumberInput(attrs={"step": "0.01", "readonly": True})),
+            "amount": _widget_with_class(forms.NumberInput(attrs={"step": "0.01", "readonly": True})),
+            "description": _widget_with_class(forms.Textarea(attrs={"rows": 3})),
+        }
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        for field in ["iva_amount", "additional_tax_amount", "amount"]:
+            self.fields[field].required = False
+            self.fields[field].widget.attrs["readonly"] = True
+            self.fields[field].initial = Decimal("0.00")
+        self.fields["additional_tax_type"].initial = Invoice.ADDITIONAL_TAX_NONE
+        self.fields["iva_rate"].initial = Invoice.IVA_21
+
+    def clean(self) -> dict[str, object]:
+        cleaned_data = super().clean()
+        invoice_type = cleaned_data.get("invoice_type")
+        client = cleaned_data.get("client")
+        supplier = cleaned_data.get("supplier")
+        if invoice_type == Invoice.TYPE_SALE and not client:
+            self.add_error("client", "Seleccioná un cliente para la factura de venta.")
+        if invoice_type == Invoice.TYPE_PURCHASE and not supplier:
+            self.add_error("supplier", "Seleccioná un proveedor para la factura de compra.")
+        gross_amount = cleaned_data.get("gross_amount")
+        iva_rate = cleaned_data.get("iva_rate")
+        if gross_amount is not None and iva_rate is not None:
+            iva_amount = (gross_amount * iva_rate).quantize(Decimal("0.01"))
+            cleaned_data["iva_amount"] = iva_amount
+            additional_tax_type = cleaned_data.get("additional_tax_type") or Invoice.ADDITIONAL_TAX_NONE
+            if additional_tax_type == Invoice.ADDITIONAL_TAX_IB_BSAS:
+                additional_rate = Decimal("0.035")
+            elif additional_tax_type == Invoice.ADDITIONAL_TAX_IB_CABA:
+                additional_rate = Decimal("0.03")
+            elif additional_tax_type == Invoice.ADDITIONAL_TAX_PERCEPTION_IVA:
+                additional_rate = Decimal("0.03")
+            else:
+                additional_rate = Decimal("0")
+            additional_amount = (gross_amount * additional_rate).quantize(Decimal("0.01"))
+            cleaned_data["additional_tax_amount"] = additional_amount
+            cleaned_data["amount"] = (gross_amount + iva_amount + additional_amount).quantize(Decimal("0.01"))
+            self.data = self.data.copy()
+            for field, value in {
+                "iva_amount": iva_amount,
+                "additional_tax_amount": additional_amount,
+                "amount": cleaned_data["amount"],
+            }.items():
+                self.data[field] = f"{value:.2f}"
+        return cleaned_data
+
+
+class ExpenseForm(forms.ModelForm):
+    class Meta:
+        model = Expense
+        fields = ["category", "description", "date", "amount"]
+        widgets = {
+            "category": _widget_with_class(forms.TextInput()),
+            "description": _widget_with_class(forms.Textarea(attrs={"rows": 2})),
+            "date": _widget_with_class(forms.DateInput(attrs={"type": "date"})),
+            "amount": _widget_with_class(forms.NumberInput(attrs={"step": "0.01"})),
+        }
+
+
+class RemittanceForm(forms.ModelForm):
+    class Meta:
+        model = Remittance
+        fields = ["number", "date", "client", "order", "description"]
+        widgets = {
+            "number": _widget_with_class(forms.TextInput()),
+            "date": _widget_with_class(forms.DateInput(attrs={"type": "date"})),
+            "client": _widget_with_class(forms.Select()),
+            "order": _widget_with_class(forms.Select()),
+            "description": _widget_with_class(forms.Textarea(attrs={"rows": 3})),
+        }
+
+
+class ReportFilterForm(forms.Form):
+    report_type = forms.ChoiceField(
+        label="Tipo de reporte",
+        choices=[
+            ("current_account_client", "Cuenta corriente (clientes)"),
+            ("current_account_supplier", "Cuenta corriente (proveedores)"),
+            ("analytical", "Analítico de cuenta"),
+        ],
+        widget=_widget_with_class(forms.Select()),
+    )
+    client = forms.ModelChoiceField(
+        label="Cliente",
+        queryset=Client.objects.all(),
+        required=False,
+        widget=_widget_with_class(forms.Select()),
+    )
+    supplier = forms.ModelChoiceField(
+        label="Proveedor",
+        queryset=Supplier.objects.all(),
+        required=False,
+        widget=_widget_with_class(forms.Select()),
+    )
+    date_from = forms.DateField(
+        label="Desde",
+        required=False,
+        widget=_widget_with_class(forms.DateInput(attrs={"type": "date"})),
+    )
+    date_to = forms.DateField(
+        label="Hasta",
+        required=False,
+        widget=_widget_with_class(forms.DateInput(attrs={"type": "date"})),
+    )
+
+
+class CurrentAccountMovementForm(forms.ModelForm):
+    class Meta:
+        model = CurrentAccountMovement
+        fields = ["movement_type", "date", "client", "supplier", "concept", "amount"]
+        widgets = {
+            "movement_type": _widget_with_class(forms.Select()),
+            "date": _widget_with_class(forms.DateInput(attrs={"type": "date"})),
+            "client": _widget_with_class(forms.Select()),
+            "supplier": _widget_with_class(forms.Select()),
+            "concept": _widget_with_class(forms.TextInput()),
+            "amount": _widget_with_class(forms.NumberInput(attrs={"step": "0.01"})),
+        }
+
+
+class AccountingRecordForm(forms.ModelForm):
+    class Meta:
+        model = AccountingRecord
+        fields = [
+            "record_type",
+            "date",
+            "description",
+            "client",
+            "supplier",
+            "document_number",
+            "debit",
+            "credit",
+        ]
+        widgets = {
+            "record_type": _widget_with_class(forms.Select()),
+            "date": _widget_with_class(forms.DateInput(attrs={"type": "date"})),
+            "description": _widget_with_class(forms.TextInput()),
+            "client": _widget_with_class(forms.Select()),
+            "supplier": _widget_with_class(forms.Select()),
+            "document_number": _widget_with_class(forms.TextInput()),
+            "debit": _widget_with_class(forms.NumberInput(attrs={"step": "0.01"})),
+            "credit": _widget_with_class(forms.NumberInput(attrs={"step": "0.01"})),
+        }
+
+
+class OrderPhotoForm(forms.Form):
+    image = forms.ImageField(label="Foto")
+    description = forms.CharField(
+        label="Descripción",
+        required=False,
+        widget=_widget_with_class(forms.Textarea(attrs={"rows": 2})),
+    )
+    materials = forms.ModelMultipleChoiceField(
+        queryset=Material.objects.none(),
+        required=False,
+        widget=forms.CheckboxSelectMultiple(),
+        label="Materiales utilizados",
+    )
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.fields["materials"].queryset = Material.objects.all()
+        self.fields["image"].widget = _widget_with_class(self.fields["image"].widget)
+        self.fields["materials"].widget.attrs.setdefault("class", "form-check-input")
+
+
+def update_order_item_formset_labels(formset: Iterable[OrderItemForm]) -> None:
+    label_map = {key: label for key, label in ORDER_ITEM_PRESETS}
+    for form in formset:
+        preset_key = form.initial.get("preset_key") or form.data.get(form.add_prefix("preset_key"))
+        if preset_key and not form.initial.get("preset_name"):
+            form.fields["preset_name"].initial = label_map.get(preset_key, "")
+        form.fields["preset_name"].widget = _widget_with_class(forms.TextInput())
+        form.fields["detail"].widget = _widget_with_class(forms.TextInput())
+        form.fields["colors"].widget = _widget_with_class(forms.TextInput())
+        form.fields["measure"].widget = _widget_with_class(forms.TextInput())
+        form.fields["quantity"].widget = _widget_with_class(forms.NumberInput(attrs={"step": "0.01"}))
+        form.fields["unit_price"].widget = _widget_with_class(forms.NumberInput(attrs={"step": "0.01"}))
+        form.fields["total_amount"].widget = _widget_with_class(forms.NumberInput(attrs={"step": "0.01"}))

--- a/core/migrations/0001_initial.py
+++ b/core/migrations/0001_initial.py
@@ -1,0 +1,412 @@
+# Generated manually to bootstrap RV Gráfica models
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+from django.conf import settings
+from django.core.validators import MinValueValidator
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Client",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("name", models.CharField(max_length=255)),
+                ("service_line", models.CharField(blank=True, max_length=255, verbose_name="Empresa / Línea")),
+                ("contact_name", models.CharField(blank=True, max_length=255, verbose_name="Nombre y apellido")),
+                ("email", models.EmailField(blank=True, max_length=254)),
+                ("phone", models.CharField(blank=True, max_length=100)),
+                ("notes", models.TextField(blank=True)),
+            ],
+            options={
+                "ordering": ["name"],
+            },
+        ),
+        migrations.CreateModel(
+            name="Material",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("name", models.CharField(max_length=100, unique=True)),
+            ],
+            options={
+                "ordering": ["name"],
+            },
+        ),
+        migrations.CreateModel(
+            name="Supplier",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("name", models.CharField(max_length=255)),
+                ("contact_name", models.CharField(blank=True, max_length=255)),
+                ("email", models.EmailField(blank=True, max_length=254)),
+                ("phone", models.CharField(blank=True, max_length=100)),
+                ("notes", models.TextField(blank=True)),
+            ],
+            options={
+                "ordering": ["name"],
+            },
+        ),
+        migrations.CreateModel(
+            name="ProductionOrder",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("order_number", models.PositiveIntegerField(editable=False, unique=True)),
+                ("order_date", models.DateField(default=datetime.date.today)),
+                ("service_line", models.CharField(blank=True, max_length=255, verbose_name="Empresa / línea")),
+                ("internal_code", models.CharField(blank=True, max_length=100, verbose_name="Interno")),
+                ("bodywork", models.CharField(blank=True, max_length=255, verbose_name="Carrocería")),
+                ("contact_name", models.CharField(blank=True, max_length=255, verbose_name="Nombre y apellido")),
+                ("email", models.EmailField(blank=True, max_length=254, verbose_name="Mail")),
+                ("phone", models.CharField(blank=True, max_length=100, verbose_name="Tel")),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pendiente"),
+                            ("in_progress", "En curso"),
+                            ("completed", "Finalizada"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("notes", models.TextField(blank=True)),
+                (
+                    "client",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="orders",
+                        to="core.client",
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="created_orders",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-order_date", "-order_number"],
+            },
+        ),
+        migrations.CreateModel(
+            name="Budget",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("title", models.CharField(max_length=255)),
+                ("description", models.TextField(blank=True)),
+                ("date", models.DateField(default=datetime.date.today)),
+                (
+                    "square_meters",
+                    models.DecimalField(decimal_places=2, max_digits=10, validators=[MinValueValidator(Decimal("0"))]),
+                ),
+                (
+                    "price_per_square_meter",
+                    models.DecimalField(decimal_places=2, max_digits=10, validators=[MinValueValidator(Decimal("0"))]),
+                ),
+                (
+                    "additional_costs",
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=Decimal("0"),
+                        max_digits=10,
+                        validators=[MinValueValidator(Decimal("0"))],
+                    ),
+                ),
+                (
+                    "total_amount",
+                    models.DecimalField(decimal_places=2, editable=False, max_digits=12),
+                ),
+                (
+                    "client",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="budgets",
+                        to="core.client",
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="created_budgets",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-date", "-id"],
+            },
+        ),
+        migrations.CreateModel(
+            name="Expense",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("category", models.CharField(max_length=100)),
+                ("description", models.CharField(blank=True, max_length=255)),
+                ("date", models.DateField(default=datetime.date.today)),
+                (
+                    "amount",
+                    models.DecimalField(decimal_places=2, max_digits=12, validators=[MinValueValidator(Decimal("0"))]),
+                ),
+                (
+                    "recorded_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="expenses",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-date", "-id"],
+            },
+        ),
+        migrations.CreateModel(
+            name="Invoice",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "invoice_type",
+                    models.CharField(
+                        choices=[("sale", "Factura de venta"), ("purchase", "Factura de compra")],
+                        max_length=20,
+                    ),
+                ),
+                ("number", models.CharField(max_length=100)),
+                ("date", models.DateField(default=datetime.date.today)),
+                (
+                    "amount",
+                    models.DecimalField(decimal_places=2, max_digits=12, validators=[MinValueValidator(Decimal("0"))]),
+                ),
+                ("description", models.TextField(blank=True)),
+                (
+                    "client",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="invoices",
+                        to="core.client",
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="created_invoices",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "order",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="invoices",
+                        to="core.productionorder",
+                    ),
+                ),
+                (
+                    "supplier",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="invoices",
+                        to="core.supplier",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-date", "-id"],
+                "unique_together": {("invoice_type", "number")},
+            },
+        ),
+        migrations.CreateModel(
+            name="ProductionOrderItem",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "preset_label",
+                    models.CharField(
+                        choices=[
+                            ("trompa", "Trompa"),
+                            ("estrellas_trompa", "Estrellas trompa"),
+                            ("interno_trompa", "Interno trompa"),
+                            ("luminosos", "Luminosos"),
+                            ("culata_logo", "Culata / logo"),
+                            ("estrellas_culata", "Estrellas culata"),
+                            ("internos", "Internos"),
+                            ("lateral", "Lateral"),
+                            ("lateral_exterior", "Lateral exterior"),
+                            ("estrellas_lateral", "Estrellas lateral"),
+                            ("parabrisas", "Parabrisas / aire"),
+                            ("obo_exterior", "Oblea exterior"),
+                            ("obo_interior", "Oblea interior"),
+                            ("silletas", "Silla / pechera"),
+                            ("estribos", "Estribos"),
+                            ("banda_reflectiva", "Banda reflectiva"),
+                            ("circulo_reflectivo", "Círculo reflectivo"),
+                            ("polarizado", "Polarizado"),
+                        ],
+                        max_length=50,
+                    ),
+                ),
+                ("detail", models.CharField(blank=True, max_length=255)),
+                ("colors", models.CharField(blank=True, max_length=255)),
+                ("measure", models.CharField(blank=True, max_length=100)),
+                (
+                    "quantity",
+                    models.DecimalField(
+                        blank=True,
+                        decimal_places=2,
+                        max_digits=10,
+                        null=True,
+                        validators=[MinValueValidator(Decimal("0"))],
+                    ),
+                ),
+                (
+                    "unit_price",
+                    models.DecimalField(
+                        blank=True,
+                        decimal_places=2,
+                        max_digits=10,
+                        null=True,
+                        validators=[MinValueValidator(Decimal("0"))],
+                    ),
+                ),
+                (
+                    "total_amount",
+                    models.DecimalField(
+                        blank=True,
+                        decimal_places=2,
+                        max_digits=12,
+                        null=True,
+                        validators=[MinValueValidator(Decimal("0"))],
+                    ),
+                ),
+                (
+                    "order",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="items",
+                        to="core.productionorder",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["order", "id"],
+                "unique_together": {("order", "preset_label")},
+            },
+        ),
+        migrations.CreateModel(
+            name="OrderPhoto",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("image", models.ImageField(upload_to="orders/photos/")),
+                ("description", models.CharField(blank=True, max_length=255)),
+                (
+                    "materials",
+                    models.ManyToManyField(blank=True, related_name="order_photos", to="core.material"),
+                ),
+                (
+                    "order",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="photos",
+                        to="core.productionorder",
+                    ),
+                ),
+                (
+                    "uploaded_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="uploaded_order_photos",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.CreateModel(
+            name="UserProfile",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "role",
+                    models.CharField(
+                        choices=[
+                            ("operator", "Operativo"),
+                            ("administrative", "Administrativo"),
+                            ("admin", "Administrador"),
+                        ],
+                        default="operator",
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "user",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="profile",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Perfil de usuario",
+                "verbose_name_plural": "Perfiles de usuario",
+            },
+        ),
+    ]

--- a/core/migrations/0002_alter_productionorder_client_add_custom_description.py
+++ b/core/migrations/0002_alter_productionorder_client_add_custom_description.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="productionorderitem",
+            name="custom_description",
+            field=models.CharField(
+                blank=True,
+                default="",
+                max_length=255,
+                verbose_name="Descripción personalizada",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="productionorder",
+            name="client",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="orders",
+                to="core.client",
+            ),
+        ),
+    ]

--- a/core/migrations/0003_invoice_taxes_and_new_sections.py
+++ b/core/migrations/0003_invoice_taxes_and_new_sections.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.core.validators import MinValueValidator
+from django.db import migrations, models
+from django.utils.timezone import now
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0002_alter_productionorder_client_add_custom_description"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="invoice",
+            name="gross_amount",
+            field=models.DecimalField(
+                decimal_places=2,
+                default=Decimal("0.00"),
+                max_digits=12,
+                validators=[MinValueValidator(Decimal("0"))],
+                verbose_name="Importe neto",
+            ),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="invoice",
+            name="iva_rate",
+            field=models.DecimalField(
+                choices=[(Decimal("0.21"), "21%"), (Decimal("0.105"), "10,5%")],
+                decimal_places=3,
+                default=Decimal("0.21"),
+                max_digits=4,
+                verbose_name="Alícuota de IVA",
+            ),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="invoice",
+            name="iva_amount",
+            field=models.DecimalField(
+                decimal_places=2,
+                default=Decimal("0.00"),
+                max_digits=12,
+                validators=[MinValueValidator(Decimal("0"))],
+                verbose_name="IVA",
+            ),
+        ),
+        migrations.AddField(
+            model_name="invoice",
+            name="additional_tax_type",
+            field=models.CharField(
+                choices=[
+                    ("none", "Sin percepciones"),
+                    ("ib_bsas", "Ing. Brutos Bs. As."),
+                    ("ib_caba", "Ing. Brutos CABA"),
+                    ("percep_iva", "Percepción de IVA (3%)"),
+                ],
+                default="none",
+                max_length=20,
+                verbose_name="Percepción",
+            ),
+        ),
+        migrations.AddField(
+            model_name="invoice",
+            name="additional_tax_amount",
+            field=models.DecimalField(
+                decimal_places=2,
+                default=Decimal("0.00"),
+                max_digits=12,
+                validators=[MinValueValidator(Decimal("0"))],
+                verbose_name="Importe percepciones",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="invoice",
+            name="amount",
+            field=models.DecimalField(
+                decimal_places=2,
+                max_digits=12,
+                validators=[MinValueValidator(Decimal("0"))],
+                verbose_name="Total factura",
+            ),
+        ),
+        migrations.CreateModel(
+            name="AccountingRecord",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "record_type",
+                    models.CharField(
+                        choices=[
+                            ("subdiary_iva", "Subdiario de IVA"),
+                            ("ledger", "Mayor"),
+                            ("trial_balance", "Sumas y saldos"),
+                            ("chart_of_accounts", "Plan de cuentas"),
+                        ],
+                        max_length=30,
+                    ),
+                ),
+                ("date", models.DateField(default=now)),
+                ("description", models.CharField(max_length=255)),
+                ("document_number", models.CharField(blank=True, max_length=100)),
+                (
+                    "debit",
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=Decimal("0.00"),
+                        max_digits=12,
+                        validators=[MinValueValidator(Decimal("0"))],
+                    ),
+                ),
+                (
+                    "credit",
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=Decimal("0.00"),
+                        max_digits=12,
+                        validators=[MinValueValidator(Decimal("0"))],
+                    ),
+                ),
+                (
+                    "client",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="accounting_records",
+                        to="core.client",
+                    ),
+                ),
+                (
+                    "supplier",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="accounting_records",
+                        to="core.supplier",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-date", "-id"]},
+        ),
+        migrations.CreateModel(
+            name="CurrentAccountMovement",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "movement_type",
+                    models.CharField(
+                        choices=[
+                            ("charge", "Cobro en cuenta corriente"),
+                            ("payment", "Pago en cuenta corriente"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+                ("date", models.DateField(default=now)),
+                ("concept", models.CharField(max_length=255)),
+                (
+                    "amount",
+                    models.DecimalField(
+                        decimal_places=2,
+                        max_digits=12,
+                        validators=[MinValueValidator(Decimal("0"))],
+                    ),
+                ),
+                (
+                    "client",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="current_account_movements",
+                        to="core.client",
+                    ),
+                ),
+                (
+                    "supplier",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="current_account_movements",
+                        to="core.supplier",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-date", "-id"]},
+        ),
+        migrations.CreateModel(
+            name="Remittance",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("number", models.CharField(max_length=100)),
+                ("date", models.DateField(default=now)),
+                ("description", models.TextField(blank=True)),
+                (
+                    "client",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="remittances",
+                        to="core.client",
+                    ),
+                ),
+                (
+                    "order",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="remittances",
+                        to="core.productionorder",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-date", "-id"]},
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -1,0 +1,573 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.core.validators import MinValueValidator
+from django.db import models
+from django.db.models import Max
+from django.utils import timezone
+
+User = get_user_model()
+
+
+class TimeStampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+
+
+class Client(TimeStampedModel):
+    name = models.CharField(max_length=255)
+    service_line = models.CharField("Empresa / Línea", max_length=255, blank=True)
+    contact_name = models.CharField("Nombre y apellido", max_length=255, blank=True)
+    email = models.EmailField(blank=True)
+    phone = models.CharField(max_length=100, blank=True)
+    notes = models.TextField(blank=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return self.name
+
+
+class Supplier(TimeStampedModel):
+    name = models.CharField(max_length=255)
+    contact_name = models.CharField(max_length=255, blank=True)
+    email = models.EmailField(blank=True)
+    phone = models.CharField(max_length=100, blank=True)
+    notes = models.TextField(blank=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return self.name
+
+
+class Material(TimeStampedModel):
+    name = models.CharField(max_length=100, unique=True)
+
+    class Meta:
+        ordering = ["name"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return self.name
+
+    @staticmethod
+    def default_materials() -> list[str]:
+        return [
+            "Reflectivo",
+            "Polarizado",
+            "Ploteo",
+            "Vinilo impreso",
+            "Microperforado",
+        ]
+
+
+ORDER_ITEM_PRESETS: list[tuple[str, str]] = [
+    ("trompa", "Trompa"),
+    ("estrellas_trompa", "Estrellas trompa"),
+    ("interno_trompa", "Interno trompa"),
+    ("luminosos", "Luminosos"),
+    ("culata_logo", "Culata / logo"),
+    ("estrellas_culata", "Estrellas culata"),
+    ("internos", "Internos"),
+    ("lateral", "Lateral"),
+    ("lateral_exterior", "Lateral exterior"),
+    ("estrellas_lateral", "Estrellas lateral"),
+    ("parabrisas", "Parabrisas / aire"),
+    ("obo_exterior", "Oblea exterior"),
+    ("obo_interior", "Oblea interior"),
+    ("silletas", "Silla / pechera"),
+    ("estribos", "Estribos"),
+    ("banda_reflectiva", "Banda reflectiva"),
+    ("circulo_reflectivo", "Círculo reflectivo"),
+    ("polarizado", "Polarizado"),
+]
+
+
+class ProductionOrder(TimeStampedModel):
+    STATUS_PENDING = "pending"
+    STATUS_IN_PROGRESS = "in_progress"
+    STATUS_COMPLETED = "completed"
+    STATUS_CHOICES = [
+        (STATUS_PENDING, "Pendiente"),
+        (STATUS_IN_PROGRESS, "En curso"),
+        (STATUS_COMPLETED, "Finalizada"),
+    ]
+
+    order_number = models.PositiveIntegerField(unique=True, editable=False)
+    client = models.ForeignKey(
+        Client,
+        on_delete=models.PROTECT,
+        related_name="orders",
+        blank=True,
+        null=True,
+    )
+    order_date = models.DateField(default=date.today)
+    service_line = models.CharField("Empresa / línea", max_length=255, blank=True)
+    internal_code = models.CharField("Interno", max_length=100, blank=True)
+    bodywork = models.CharField("Carrocería", max_length=255, blank=True)
+    contact_name = models.CharField("Nombre y apellido", max_length=255, blank=True)
+    email = models.EmailField("Mail", blank=True)
+    phone = models.CharField("Tel", max_length=100, blank=True)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=STATUS_PENDING)
+    notes = models.TextField(blank=True)
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        related_name="created_orders",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        ordering = ["-order_date", "-order_number"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        client_name = self.client.name if self.client else "Sin cliente"
+        return f"Orden #{self.order_number} - {client_name}"
+
+    def save(self, *args, **kwargs) -> None:
+        if not self.order_number:
+            max_number = ProductionOrder.objects.aggregate(Max("order_number"))["order_number__max"] or 0
+            self.order_number = max_number + 1
+        super().save(*args, **kwargs)
+
+    @property
+    def subtotal(self) -> Decimal:
+        total = Decimal("0")
+        for item in self.items.all():
+            if item.total_amount is not None:
+                total += item.total_amount
+        return total
+
+
+class ProductionOrderItem(TimeStampedModel):
+    order = models.ForeignKey(
+        ProductionOrder,
+        on_delete=models.CASCADE,
+        related_name="items",
+    )
+    preset_label = models.CharField(max_length=50, choices=ORDER_ITEM_PRESETS)
+    custom_description = models.CharField(
+        "Descripción personalizada",
+        max_length=255,
+        blank=True,
+        default="",
+    )
+    detail = models.CharField(max_length=255, blank=True)
+    colors = models.CharField(max_length=255, blank=True)
+    measure = models.CharField(max_length=100, blank=True)
+    quantity = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+        null=True,
+        blank=True,
+    )
+    unit_price = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+        null=True,
+        blank=True,
+    )
+    total_amount = models.DecimalField(
+        max_digits=12,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        unique_together = ("order", "preset_label")
+        ordering = ["order", "id"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        label = self.custom_description or self.get_preset_label_display()
+        return f"{label} ({self.order.order_number})"
+
+    def save(self, *args, **kwargs) -> None:
+        if self.total_amount is None and self.quantity is not None and self.unit_price is not None:
+            self.total_amount = (self.quantity * self.unit_price).quantize(Decimal("0.01"))
+        super().save(*args, **kwargs)
+
+
+class OrderPhoto(TimeStampedModel):
+    order = models.ForeignKey(
+        ProductionOrder,
+        on_delete=models.CASCADE,
+        related_name="photos",
+    )
+    image = models.ImageField(upload_to="orders/photos/")
+    description = models.CharField(max_length=255, blank=True)
+    materials = models.ManyToManyField(Material, blank=True, related_name="order_photos")
+    uploaded_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="uploaded_order_photos",
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return f"Foto orden {self.order.order_number}"
+
+
+class Budget(TimeStampedModel):
+    client = models.ForeignKey(Client, on_delete=models.SET_NULL, related_name="budgets", null=True, blank=True)
+    title = models.CharField(max_length=255)
+    description = models.TextField(blank=True)
+    date = models.DateField(default=timezone.now)
+    square_meters = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+    )
+    price_per_square_meter = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+    )
+    additional_costs = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        default=Decimal("0"),
+        validators=[MinValueValidator(Decimal("0"))],
+    )
+    total_amount = models.DecimalField(max_digits=12, decimal_places=2, editable=False)
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        related_name="created_budgets",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        ordering = ["-date", "-id"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return f"Presupuesto {self.title}"
+
+    def calculate_total(self) -> Decimal:
+        return (self.square_meters * self.price_per_square_meter) + self.additional_costs
+
+    def save(self, *args, **kwargs) -> None:
+        self.total_amount = self.calculate_total().quantize(Decimal("0.01"))
+        super().save(*args, **kwargs)
+
+
+class Invoice(TimeStampedModel):
+    TYPE_SALE = "sale"
+    TYPE_PURCHASE = "purchase"
+    TYPE_CHOICES = [
+        (TYPE_SALE, "Factura de venta"),
+        (TYPE_PURCHASE, "Factura de compra"),
+    ]
+
+    IVA_21 = Decimal("0.21")
+    IVA_105 = Decimal("0.105")
+    IVA_CHOICES = [
+        (IVA_21, "21%"),
+        (IVA_105, "10,5%"),
+    ]
+
+    ADDITIONAL_TAX_NONE = "none"
+    ADDITIONAL_TAX_IB_BSAS = "ib_bsas"
+    ADDITIONAL_TAX_IB_CABA = "ib_caba"
+    ADDITIONAL_TAX_PERCEPTION_IVA = "percep_iva"
+    ADDITIONAL_TAX_CHOICES = [
+        (ADDITIONAL_TAX_NONE, "Sin percepciones"),
+        (ADDITIONAL_TAX_IB_BSAS, "Ing. Brutos Bs. As."),
+        (ADDITIONAL_TAX_IB_CABA, "Ing. Brutos CABA"),
+        (ADDITIONAL_TAX_PERCEPTION_IVA, "Percepción de IVA (3%)"),
+    ]
+
+    invoice_type = models.CharField(max_length=20, choices=TYPE_CHOICES)
+    number = models.CharField(max_length=100)
+    date = models.DateField(default=timezone.now)
+    client = models.ForeignKey(
+        Client,
+        on_delete=models.SET_NULL,
+        related_name="invoices",
+        null=True,
+        blank=True,
+    )
+    supplier = models.ForeignKey(
+        Supplier,
+        on_delete=models.SET_NULL,
+        related_name="invoices",
+        null=True,
+        blank=True,
+    )
+    order = models.ForeignKey(
+        ProductionOrder,
+        on_delete=models.SET_NULL,
+        related_name="invoices",
+        null=True,
+        blank=True,
+    )
+    gross_amount = models.DecimalField(
+        "Importe neto",
+        max_digits=12,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+    )
+    iva_rate = models.DecimalField(
+        "Alícuota de IVA",
+        max_digits=4,
+        decimal_places=3,
+        choices=IVA_CHOICES,
+    )
+    iva_amount = models.DecimalField(
+        "IVA",
+        max_digits=12,
+        decimal_places=2,
+        default=Decimal("0"),
+        validators=[MinValueValidator(Decimal("0"))],
+    )
+    additional_tax_type = models.CharField(
+        "Percepción",
+        max_length=20,
+        choices=ADDITIONAL_TAX_CHOICES,
+        default=ADDITIONAL_TAX_NONE,
+    )
+    additional_tax_amount = models.DecimalField(
+        "Importe percepciones",
+        max_digits=12,
+        decimal_places=2,
+        default=Decimal("0"),
+        validators=[MinValueValidator(Decimal("0"))],
+    )
+    amount = models.DecimalField(
+        "Total factura",
+        max_digits=12,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+    )
+    description = models.TextField(blank=True)
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        related_name="created_invoices",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        ordering = ["-date", "-id"]
+        unique_together = ("invoice_type", "number")
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return f"Factura {self.number} ({self.get_invoice_type_display()})"
+
+    def clean(self) -> None:
+        if self.invoice_type == self.TYPE_SALE and not self.client:
+            raise ValidationError("Las facturas de venta requieren un cliente asociado.")
+        if self.invoice_type == self.TYPE_PURCHASE and not self.supplier:
+            raise ValidationError("Las facturas de compra requieren un proveedor asociado.")
+
+    def _additional_tax_rate(self) -> Decimal:
+        if self.additional_tax_type == self.ADDITIONAL_TAX_IB_BSAS:
+            return Decimal("0.035")
+        if self.additional_tax_type == self.ADDITIONAL_TAX_IB_CABA:
+            return Decimal("0.03")
+        if self.additional_tax_type == self.ADDITIONAL_TAX_PERCEPTION_IVA:
+            return Decimal("0.03")
+        return Decimal("0")
+
+    def calculate_totals(self) -> None:
+        self.iva_amount = (self.gross_amount * self.iva_rate).quantize(Decimal("0.01"))
+        additional_rate = self._additional_tax_rate()
+        self.additional_tax_amount = (self.gross_amount * additional_rate).quantize(Decimal("0.01"))
+        self.amount = (self.gross_amount + self.iva_amount + self.additional_tax_amount).quantize(Decimal("0.01"))
+
+    def save(self, *args, **kwargs) -> None:
+        self.calculate_totals()
+        super().save(*args, **kwargs)
+        if self.invoice_type == self.TYPE_SALE and self.order and self.order.status != ProductionOrder.STATUS_COMPLETED:
+            self.order.status = ProductionOrder.STATUS_COMPLETED
+            self.order.save(update_fields=["status", "updated_at"])
+
+
+class Remittance(TimeStampedModel):
+    number = models.CharField(max_length=100)
+    date = models.DateField(default=timezone.now)
+    client = models.ForeignKey(
+        Client,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="remittances",
+    )
+    order = models.ForeignKey(
+        ProductionOrder,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="remittances",
+    )
+    description = models.TextField(blank=True)
+
+    class Meta:
+        ordering = ["-date", "-id"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return f"Remito {self.number}"
+
+
+class CurrentAccountMovement(TimeStampedModel):
+    TYPE_CHARGE = "charge"
+    TYPE_PAYMENT = "payment"
+    TYPE_CHOICES = [
+        (TYPE_CHARGE, "Cobro en cuenta corriente"),
+        (TYPE_PAYMENT, "Pago en cuenta corriente"),
+    ]
+
+    movement_type = models.CharField(max_length=20, choices=TYPE_CHOICES)
+    date = models.DateField(default=timezone.now)
+    client = models.ForeignKey(
+        Client,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="current_account_movements",
+    )
+    supplier = models.ForeignKey(
+        Supplier,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="current_account_movements",
+    )
+    concept = models.CharField(max_length=255)
+    amount = models.DecimalField(
+        max_digits=12,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+    )
+
+    class Meta:
+        ordering = ["-date", "-id"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return f"{self.get_movement_type_display()} - {self.amount}"
+
+
+class AccountingRecord(TimeStampedModel):
+    TYPE_SUBDIARY_IVA = "subdiary_iva"
+    TYPE_LEDGER = "ledger"
+    TYPE_TRIAL_BALANCE = "trial_balance"
+    TYPE_CHART_OF_ACCOUNTS = "chart_of_accounts"
+    TYPE_CHOICES = [
+        (TYPE_SUBDIARY_IVA, "Subdiario de IVA"),
+        (TYPE_LEDGER, "Mayor"),
+        (TYPE_TRIAL_BALANCE, "Sumas y saldos"),
+        (TYPE_CHART_OF_ACCOUNTS, "Plan de cuentas"),
+    ]
+
+    record_type = models.CharField(max_length=30, choices=TYPE_CHOICES)
+    date = models.DateField(default=timezone.now)
+    description = models.CharField(max_length=255)
+    client = models.ForeignKey(
+        Client,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="accounting_records",
+    )
+    supplier = models.ForeignKey(
+        Supplier,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="accounting_records",
+    )
+    document_number = models.CharField(max_length=100, blank=True)
+    debit = models.DecimalField(
+        max_digits=12,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+        default=Decimal("0"),
+    )
+    credit = models.DecimalField(
+        max_digits=12,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+        default=Decimal("0"),
+    )
+
+    class Meta:
+        ordering = ["-date", "-id"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return f"{self.get_record_type_display()} - {self.description}"
+
+
+class Expense(TimeStampedModel):
+    category = models.CharField(max_length=100)
+    description = models.CharField(max_length=255, blank=True)
+    date = models.DateField(default=timezone.now)
+    amount = models.DecimalField(
+        max_digits=12,
+        decimal_places=2,
+        validators=[MinValueValidator(Decimal("0"))],
+    )
+    recorded_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        related_name="expenses",
+        null=True,
+        blank=True,
+    )
+
+    class Meta:
+        ordering = ["-date", "-id"]
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return f"Gasto {self.category} - {self.amount}"
+
+
+class UserProfile(TimeStampedModel):
+    ROLE_OPERATOR = "operator"
+    ROLE_ADMINISTRATIVE = "administrative"
+    ROLE_ADMIN = "admin"
+    ROLE_CHOICES = [
+        (ROLE_OPERATOR, "Operativo"),
+        (ROLE_ADMINISTRATIVE, "Administrativo"),
+        (ROLE_ADMIN, "Administrador"),
+    ]
+
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="profile")
+    role = models.CharField(max_length=20, choices=ROLE_CHOICES, default=ROLE_OPERATOR)
+
+    class Meta:
+        verbose_name = "Perfil de usuario"
+        verbose_name_plural = "Perfiles de usuario"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial representation
+        return f"{self.user.get_full_name() or self.user.username} ({self.get_role_display()})"
+
+    @property
+    def is_operator(self) -> bool:
+        return self.role == self.ROLE_OPERATOR
+
+    @property
+    def is_administrative(self) -> bool:
+        return self.role in {self.ROLE_ADMINISTRATIVE, self.ROLE_ADMIN}
+
+    @property
+    def is_admin(self) -> bool:
+        return self.role == self.ROLE_ADMIN

--- a/core/signals.py
+++ b/core/signals.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.db.models.signals import post_migrate, post_save
+from django.dispatch import receiver
+
+from .models import Material, UserProfile
+
+User = get_user_model()
+
+
+@receiver(post_save, sender=User)
+def create_user_profile(sender, instance, created, **kwargs):
+    if created:
+        UserProfile.objects.create(user=instance)
+
+
+@receiver(post_save, sender=User)
+def save_user_profile(sender, instance, **kwargs):
+    if hasattr(instance, "profile"):
+        instance.profile.save()
+
+
+@receiver(post_migrate)
+def ensure_default_materials(sender, **kwargs):
+    if sender.name != "core":
+        return
+    existing = set(Material.objects.values_list("name", flat=True))
+    for material_name in Material.default_materials():
+        if material_name not in existing:
+            Material.objects.get_or_create(name=material_name)

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("", views.DashboardView.as_view(), name="dashboard"),
+    path("ordenes/", views.ProductionOrderListView.as_view(), name="order_list"),
+    path("ordenes/nueva/", views.ProductionOrderCreateView.as_view(), name="order_create"),
+    path("ordenes/<int:pk>/", views.ProductionOrderDetailView.as_view(), name="order_detail"),
+    path("ordenes/<int:pk>/editar/", views.ProductionOrderUpdateView.as_view(), name="order_update"),
+    path("presupuestos/", views.BudgetListView.as_view(), name="budget_list"),
+    path("presupuestos/nuevo/", views.BudgetCreateView.as_view(), name="budget_create"),
+    path("presupuestos/<int:pk>/editar/", views.BudgetUpdateView.as_view(), name="budget_update"),
+    path("facturacion/", views.InvoiceListView.as_view(), name="invoice_list"),
+    path("facturacion/nueva/", views.InvoiceCreateView.as_view(), name="invoice_create"),
+    path("facturacion/remitos/", views.RemittanceListView.as_view(), name="remittance_list"),
+    path("facturacion/remitos/nuevo/", views.RemittanceCreateView.as_view(), name="remittance_create"),
+    path("gastos/", views.ExpenseListView.as_view(), name="expense_list"),
+    path("gastos/nuevo/", views.ExpenseCreateView.as_view(), name="expense_create"),
+    path("clientes/", views.ClientListView.as_view(), name="client_list"),
+    path("clientes/nuevo/", views.ClientCreateView.as_view(), name="client_create"),
+    path("clientes/<int:pk>/editar/", views.ClientUpdateView.as_view(), name="client_update"),
+    path("proveedores/", views.SupplierListView.as_view(), name="supplier_list"),
+    path("proveedores/nuevo/", views.SupplierCreateView.as_view(), name="supplier_create"),
+    path("proveedores/<int:pk>/editar/", views.SupplierUpdateView.as_view(), name="supplier_update"),
+    path("reportes/", views.ReportsView.as_view(), name="reports"),
+    path("finanzas/", views.FinanceMovementListView.as_view(), name="finance_movement_list"),
+    path("finanzas/nuevo/", views.FinanceMovementCreateView.as_view(), name="finance_movement_create"),
+    path("contabilidad/", views.AccountingRecordListView.as_view(), name="accounting_record_list"),
+    path("contabilidad/nuevo/", views.AccountingRecordCreateView.as_view(), name="accounting_record_create"),
+]

--- a/core/views.py
+++ b/core/views.py
@@ -1,0 +1,625 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.db import models
+from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
+from django.shortcuts import redirect
+from django.views.generic import DetailView, ListView, TemplateView
+
+from .forms import (
+    AccountingRecordForm,
+    BudgetForm,
+    ClientForm,
+    CurrentAccountMovementForm,
+    ExpenseForm,
+    InvoiceForm,
+    OrderItemForm,
+    OrderItemFormSet,
+    OrderPhotoForm,
+    ProductionOrderForm,
+    RemittanceForm,
+    ReportFilterForm,
+    SupplierForm,
+    update_order_item_formset_labels,
+)
+from .models import (
+    AccountingRecord,
+    Budget,
+    Client,
+    CurrentAccountMovement,
+    Expense,
+    Invoice,
+    ORDER_ITEM_PRESETS,
+    OrderPhoto,
+    ProductionOrder,
+    ProductionOrderItem,
+    Remittance,
+    Supplier,
+    UserProfile,
+)
+
+
+class RoleRequiredMixin(UserPassesTestMixin):
+    allowed_roles: set[str] = set()
+
+    def test_func(self) -> bool:
+        user = self.request.user
+        if not user.is_authenticated:
+            return False
+        if user.is_superuser:
+            return True
+        profile = getattr(user, "profile", None)
+        return bool(profile and profile.role in self.allowed_roles)
+
+    def handle_no_permission(self) -> HttpResponse:
+        if not self.request.user.is_authenticated:
+            return super().handle_no_permission()
+        return HttpResponseForbidden("No tenés permisos para acceder a esta sección.")
+
+
+class AdministrativeRequiredMixin(LoginRequiredMixin, RoleRequiredMixin):
+    allowed_roles = {UserProfile.ROLE_ADMINISTRATIVE, UserProfile.ROLE_ADMIN}
+
+
+class AdminOnlyMixin(LoginRequiredMixin, RoleRequiredMixin):
+    allowed_roles = {UserProfile.ROLE_ADMIN}
+
+
+class DashboardView(LoginRequiredMixin, TemplateView):
+    template_name = "core/dashboard.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["pending_orders"] = ProductionOrder.objects.filter(status=ProductionOrder.STATUS_PENDING).count()
+        context["in_progress_orders"] = ProductionOrder.objects.filter(status=ProductionOrder.STATUS_IN_PROGRESS).count()
+        context["completed_orders"] = ProductionOrder.objects.filter(status=ProductionOrder.STATUS_COMPLETED).count()
+        context["budgets_count"] = Budget.objects.count()
+        context["sales_invoices"] = Invoice.objects.filter(invoice_type=Invoice.TYPE_SALE).count()
+        context["purchase_invoices"] = Invoice.objects.filter(invoice_type=Invoice.TYPE_PURCHASE).count()
+        expenses = Expense.objects.aggregate(total=models.Sum("amount"))
+        context["expense_total"] = expenses.get("total") or 0
+        profile = getattr(self.request.user, "profile", None)
+        context["can_manage_orders"] = self.request.user.is_superuser or (
+            profile and profile.is_administrative
+        )
+        return context
+
+
+def build_order_item_initial(order: ProductionOrder | None = None) -> list[dict[str, object]]:
+    items_map = {}
+    if order is not None:
+        items_map = {item.preset_label: item for item in order.items.all()}
+    initial: list[dict[str, object]] = []
+    for key, label in ORDER_ITEM_PRESETS:
+        item = items_map.get(key)
+        initial.append(
+            {
+                "preset_key": key,
+                "preset_name": (item.custom_description if item and item.custom_description else label),
+                "detail": item.detail if item else "",
+                "colors": item.colors if item else "",
+                "measure": item.measure if item else "",
+                "quantity": item.quantity,
+                "unit_price": item.unit_price,
+                "total_amount": item.total_amount,
+            }
+        )
+    return initial
+
+
+def save_order_items(order: ProductionOrder, formset: Iterable[OrderItemForm]) -> None:
+    for form in formset:
+        if not form.cleaned_data:
+            continue
+        preset_key = form.cleaned_data.get("preset_key")
+        if not preset_key:
+            continue
+        ProductionOrderItem.objects.update_or_create(
+            order=order,
+            preset_label=preset_key,
+            defaults={
+                "custom_description": form.cleaned_data.get("preset_name", ""),
+                "detail": form.cleaned_data.get("detail", ""),
+                "colors": form.cleaned_data.get("colors", ""),
+                "measure": form.cleaned_data.get("measure", ""),
+                "quantity": form.cleaned_data.get("quantity"),
+                "unit_price": form.cleaned_data.get("unit_price"),
+                "total_amount": form.cleaned_data.get("total_amount"),
+            },
+        )
+
+
+class ProductionOrderListView(LoginRequiredMixin, ListView):
+    template_name = "core/order_list.html"
+    model = ProductionOrder
+    paginate_by = 20
+
+    def get_queryset(self):
+        queryset = super().get_queryset().select_related("client")
+        status = self.request.GET.get("estado")
+        if status in {choice[0] for choice in ProductionOrder.STATUS_CHOICES}:
+            queryset = queryset.filter(status=status)
+        search = self.request.GET.get("q")
+        if search:
+            queryset = queryset.filter(models.Q(client__name__icontains=search) | models.Q(order_number__icontains=search))
+        return queryset.order_by("-order_date", "-order_number")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["status"] = self.request.GET.get("estado", "")
+        context["search"] = self.request.GET.get("q", "")
+        profile = getattr(self.request.user, "profile", None)
+        context["can_manage_orders"] = self.request.user.is_superuser or (
+            profile and profile.is_administrative
+        )
+        return context
+
+
+class ProductionOrderCreateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/order_form.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ProductionOrderForm(initial={"status": ProductionOrder.STATUS_PENDING})
+        formset = OrderItemFormSet(initial=build_order_item_initial())
+        update_order_item_formset_labels(formset)
+        context = {
+            "form": form,
+            "formset": formset,
+            "is_edit": False,
+            "default_status": ProductionOrder.STATUS_PENDING,
+        }
+        return self.render_to_response(context)
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ProductionOrderForm(request.POST)
+        formset = OrderItemFormSet(request.POST)
+        update_order_item_formset_labels(formset)
+        if form.is_valid() and formset.is_valid():
+            order = form.save(commit=False)
+            order.created_by = request.user
+            order.save()
+            save_order_items(order, formset)
+            messages.success(request, "Orden de producción creada correctamente.")
+            return redirect("order_detail", pk=order.pk)
+        messages.error(request, "Revisá los datos cargados. Hay errores en el formulario.")
+        context = {
+            "form": form,
+            "formset": formset,
+            "is_edit": False,
+            "default_status": ProductionOrder.STATUS_PENDING,
+        }
+        return self.render_to_response(context)
+
+
+class ProductionOrderUpdateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/order_form.html"
+
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        self.order = ProductionOrder.objects.select_related("client").get(pk=kwargs["pk"])
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ProductionOrderForm(instance=self.order)
+        formset = OrderItemFormSet(initial=build_order_item_initial(self.order))
+        update_order_item_formset_labels(formset)
+        context = {
+            "form": form,
+            "formset": formset,
+            "is_edit": True,
+            "order": self.order,
+            "default_status": self.order.status,
+        }
+        return self.render_to_response(context)
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ProductionOrderForm(request.POST, instance=self.order)
+        formset = OrderItemFormSet(request.POST)
+        update_order_item_formset_labels(formset)
+        if form.is_valid() and formset.is_valid():
+            order = form.save()
+            save_order_items(order, formset)
+            messages.success(request, "Orden de producción actualizada.")
+            return redirect("order_detail", pk=order.pk)
+        messages.error(request, "No se pudo actualizar la orden. Verificá la información ingresada.")
+        context = {
+            "form": form,
+            "formset": formset,
+            "is_edit": True,
+            "order": self.order,
+            "default_status": self.order.status,
+        }
+        return self.render_to_response(context)
+
+
+class ProductionOrderDetailView(LoginRequiredMixin, DetailView):
+    template_name = "core/order_detail.html"
+    model = ProductionOrder
+
+    def get_ordered_items(self) -> list[ProductionOrderItem]:
+        order = self.get_object()
+        items_map = {item.preset_label: item for item in order.items.all()}
+        ordered_items: list[ProductionOrderItem] = []
+        for key, _ in ORDER_ITEM_PRESETS:
+            if key in items_map:
+                ordered_items.append(items_map[key])
+            else:
+                ordered_items.append(ProductionOrderItem(order=order, preset_label=key))
+        return ordered_items
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        order = self.object
+        context["items"] = self.get_ordered_items()
+        photo_form = kwargs.get("photo_form") or OrderPhotoForm()
+        context["photo_form"] = photo_form
+        profile = getattr(self.request.user, "profile", None)
+        context["can_edit"] = self.request.user.is_superuser or (
+            profile and profile.is_administrative
+        )
+        context["can_upload"] = can_upload_photos(self.request.user)
+        context["photos"] = order.photos.select_related("uploaded_by").prefetch_related("materials")
+        return context
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        self.object = self.get_object()
+        if not can_upload_photos(request.user):
+            return HttpResponseForbidden("No tenés permisos para subir fotos.")
+        form = OrderPhotoForm(request.POST, request.FILES)
+        if form.is_valid():
+            photo = OrderPhoto.objects.create(
+                order=self.object,
+                image=form.cleaned_data["image"],
+                description=form.cleaned_data.get("description", ""),
+                uploaded_by=request.user,
+            )
+            if form.cleaned_data.get("materials"):
+                photo.materials.set(form.cleaned_data["materials"])
+            messages.success(request, "Foto subida correctamente.")
+            return redirect("order_detail", pk=self.object.pk)
+        context = self.get_context_data(photo_form=form)
+        return self.render_to_response(context)
+
+
+def can_upload_photos(user) -> bool:
+    if not user.is_authenticated:
+        return False
+    if user.is_superuser:
+        return True
+    profile = getattr(user, "profile", None)
+    return bool(profile and profile.role in {UserProfile.ROLE_OPERATOR, UserProfile.ROLE_ADMINISTRATIVE, UserProfile.ROLE_ADMIN})
+
+
+class BudgetListView(AdministrativeRequiredMixin, ListView):
+    template_name = "core/budget_list.html"
+    model = Budget
+    paginate_by = 20
+
+
+class BudgetCreateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/budget_form.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = BudgetForm()
+        return self.render_to_response({"form": form, "is_edit": False})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = BudgetForm(request.POST)
+        if form.is_valid():
+            budget = form.save(commit=False)
+            budget.created_by = request.user
+            budget.save()
+            messages.success(request, "Presupuesto guardado correctamente.")
+            return redirect("budget_list")
+        messages.error(request, "Hay errores en el formulario de presupuesto.")
+        return self.render_to_response({"form": form, "is_edit": False})
+
+
+class BudgetUpdateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/budget_form.html"
+
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        self.budget = Budget.objects.get(pk=kwargs["pk"])
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = BudgetForm(instance=self.budget)
+        return self.render_to_response({"form": form, "is_edit": True, "budget": self.budget})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = BudgetForm(request.POST, instance=self.budget)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Presupuesto actualizado.")
+            return redirect("budget_list")
+        messages.error(request, "No se pudo actualizar el presupuesto.")
+        return self.render_to_response({"form": form, "is_edit": True, "budget": self.budget})
+
+
+class InvoiceListView(AdministrativeRequiredMixin, ListView):
+    template_name = "core/invoice_list.html"
+    model = Invoice
+    paginate_by = 20
+
+    def get_queryset(self):
+        queryset = super().get_queryset().select_related("client", "supplier", "order")
+        invoice_type = self.request.GET.get("tipo")
+        if invoice_type in {choice[0] for choice in Invoice.TYPE_CHOICES}:
+            queryset = queryset.filter(invoice_type=invoice_type)
+        return queryset.order_by("-date", "-id")
+
+
+class InvoiceCreateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/invoice_form.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = InvoiceForm()
+        return self.render_to_response({"form": form})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = InvoiceForm(request.POST)
+        if form.is_valid():
+            invoice = form.save(commit=False)
+            invoice.created_by = request.user
+            invoice.save()
+            messages.success(request, "Factura guardada correctamente.")
+            return redirect("invoice_list")
+        messages.error(request, "Hay errores en la carga de la factura.")
+        return self.render_to_response({"form": form})
+
+
+class RemittanceListView(AdministrativeRequiredMixin, ListView):
+    template_name = "core/remittance_list.html"
+    model = Remittance
+    paginate_by = 20
+    ordering = ["-date", "-id"]
+
+
+class RemittanceCreateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/remittance_form.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = RemittanceForm()
+        return self.render_to_response({"form": form})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = RemittanceForm(request.POST)
+        if form.is_valid():
+            remittance = form.save()
+            messages.success(request, "Remito registrado correctamente.")
+            return redirect("remittance_list")
+        messages.error(request, "No se pudo guardar el remito.")
+        return self.render_to_response({"form": form})
+
+
+class ExpenseListView(AdministrativeRequiredMixin, ListView):
+    template_name = "core/expense_list.html"
+    model = Expense
+    paginate_by = 20
+    ordering = ["-date", "-id"]
+
+
+class ExpenseCreateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/expense_form.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ExpenseForm()
+        return self.render_to_response({"form": form})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ExpenseForm(request.POST)
+        if form.is_valid():
+            expense = form.save(commit=False)
+            expense.recorded_by = request.user
+            expense.save()
+            messages.success(request, "Gasto registrado.")
+            return redirect("expense_list")
+        messages.error(request, "No se pudo guardar el gasto.")
+        return self.render_to_response({"form": form})
+
+
+class ClientListView(AdministrativeRequiredMixin, ListView):
+    template_name = "core/client_list.html"
+    model = Client
+    paginate_by = 50
+    ordering = ["name"]
+
+
+class ClientCreateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/client_form.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ClientForm()
+        return self.render_to_response({"form": form, "is_edit": False})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ClientForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Cliente agregado.")
+            return redirect("client_list")
+        return self.render_to_response({"form": form, "is_edit": False})
+
+
+class ClientUpdateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/client_form.html"
+
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        self.client = Client.objects.get(pk=kwargs["pk"])
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ClientForm(instance=self.client)
+        return self.render_to_response({"form": form, "is_edit": True, "client": self.client})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ClientForm(request.POST, instance=self.client)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Cliente actualizado.")
+            return redirect("client_list")
+        return self.render_to_response({"form": form, "is_edit": True, "client": self.client})
+
+
+class SupplierListView(AdministrativeRequiredMixin, ListView):
+    template_name = "core/supplier_list.html"
+    model = Supplier
+    paginate_by = 50
+    ordering = ["name"]
+
+
+class SupplierCreateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/supplier_form.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = SupplierForm()
+        return self.render_to_response({"form": form, "is_edit": False})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = SupplierForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Proveedor agregado.")
+            return redirect("supplier_list")
+        return self.render_to_response({"form": form, "is_edit": False})
+
+
+class SupplierUpdateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/supplier_form.html"
+
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        self.supplier = Supplier.objects.get(pk=kwargs["pk"])
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = SupplierForm(instance=self.supplier)
+        return self.render_to_response({"form": form, "is_edit": True, "supplier": self.supplier})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = SupplierForm(request.POST, instance=self.supplier)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Proveedor actualizado.")
+            return redirect("supplier_list")
+        return self.render_to_response({"form": form, "is_edit": True, "supplier": self.supplier})
+
+
+class ReportsView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/reports.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = ReportFilterForm(request.GET or None)
+        report_context = self.build_report(form) if form.is_valid() else {}
+        report_context.setdefault("entries", [])
+        report_context.setdefault("balance", 0)
+        return self.render_to_response({"form": form, "report": report_context})
+
+    def build_report(self, form: ReportFilterForm) -> dict[str, object]:
+        data = form.cleaned_data
+        report_type = data.get("report_type")
+        date_from = data.get("date_from")
+        date_to = data.get("date_to")
+        queryset = CurrentAccountMovement.objects.all()
+        if date_from:
+            queryset = queryset.filter(date__gte=date_from)
+        if date_to:
+            queryset = queryset.filter(date__lte=date_to)
+        if report_type == "current_account_client" and data.get("client"):
+            queryset = queryset.filter(client=data["client"])
+        if report_type == "current_account_supplier" and data.get("supplier"):
+            queryset = queryset.filter(supplier=data["supplier"])
+
+        entries = queryset.select_related("client", "supplier").order_by("-date", "-id")
+        balance = 0
+        detailed_entries = []
+        for movement in entries:
+            amount = movement.amount
+            if movement.movement_type == CurrentAccountMovement.TYPE_PAYMENT:
+                balance -= amount
+            else:
+                balance += amount
+            detailed_entries.append(
+                {
+                    "date": movement.date,
+                    "concept": movement.concept,
+                    "client": movement.client,
+                    "supplier": movement.supplier,
+                    "movement_type": movement.get_movement_type_display(),
+                    "amount": amount,
+                }
+            )
+
+        return {
+            "entries": detailed_entries,
+            "balance": balance,
+            "report_type": report_type,
+        }
+
+
+class FinanceMovementListView(AdministrativeRequiredMixin, ListView):
+    template_name = "core/finance_movement_list.html"
+    model = CurrentAccountMovement
+    paginate_by = 20
+    ordering = ["-date", "-id"]
+
+    def get_queryset(self):
+        queryset = super().get_queryset().select_related("client", "supplier")
+        movement_type = self.request.GET.get("tipo")
+        if movement_type in {choice[0] for choice in CurrentAccountMovement.TYPE_CHOICES}:
+            queryset = queryset.filter(movement_type=movement_type)
+        return queryset
+
+
+class FinanceMovementCreateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/finance_movement_form.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = CurrentAccountMovementForm()
+        return self.render_to_response({"form": form})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = CurrentAccountMovementForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Movimiento de cuenta corriente registrado.")
+            return redirect("finance_movement_list")
+        messages.error(request, "No se pudo guardar el movimiento.")
+        return self.render_to_response({"form": form})
+
+
+class AccountingRecordListView(AdministrativeRequiredMixin, ListView):
+    template_name = "core/accounting_record_list.html"
+    model = AccountingRecord
+    paginate_by = 20
+
+    def get_queryset(self):
+        queryset = super().get_queryset().select_related("client", "supplier")
+        record_type = self.request.GET.get("tipo")
+        if record_type in {choice[0] for choice in AccountingRecord.TYPE_CHOICES}:
+            queryset = queryset.filter(record_type=record_type)
+        date_from = self.request.GET.get("desde")
+        date_to = self.request.GET.get("hasta")
+        if date_from:
+            queryset = queryset.filter(date__gte=date_from)
+        if date_to:
+            queryset = queryset.filter(date__lte=date_to)
+        return queryset.order_by("-date", "-id")
+
+
+class AccountingRecordCreateView(AdministrativeRequiredMixin, TemplateView):
+    template_name = "core/accounting_record_form.html"
+
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = AccountingRecordForm()
+        return self.render_to_response({"form": form})
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        form = AccountingRecordForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Registro contable cargado correctamente.")
+            return redirect("accounting_record_list")
+        messages.error(request, "No se pudo guardar el registro contable.")
+        return self.render_to_response({"form": form})

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main() -> None:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "rv_grafica.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and available on your PYTHONPATH environment variable? Did you forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/rv_grafica/asgi.py
+++ b/rv_grafica/asgi.py
@@ -1,0 +1,10 @@
+"""ASGI config for rv_grafica project."""
+from __future__ import annotations
+
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "rv_grafica.settings")
+
+application = get_asgi_application()

--- a/rv_grafica/settings.py
+++ b/rv_grafica/settings.py
@@ -1,0 +1,95 @@
+"""Django settings for rv_grafica project."""
+from __future__ import annotations
+
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = "django-insecure-change-me"
+
+DEBUG = True
+
+ALLOWED_HOSTS: list[str] = []
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "core.apps.CoreConfig",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "rv_grafica.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    }
+]
+
+WSGI_APPLICATION = "rv_grafica.wsgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
+]
+
+LANGUAGE_CODE = "es-ar"
+
+TIME_ZONE = "America/Argentina/Buenos_Aires"
+
+USE_I18N = True
+
+USE_TZ = True
+
+STATIC_URL = "static/"
+STATICFILES_DIRS = [BASE_DIR / "static"]
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
+MEDIA_URL = "media/"
+MEDIA_ROOT = BASE_DIR / "media"
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+LOGIN_URL = "login"
+LOGIN_REDIRECT_URL = "dashboard"
+LOGOUT_REDIRECT_URL = "login"

--- a/rv_grafica/urls.py
+++ b/rv_grafica/urls.py
@@ -1,0 +1,17 @@
+"""rv_grafica URL Configuration."""
+from __future__ import annotations
+
+from django.conf import settings
+from django.conf.urls.static import static
+from django.contrib import admin
+from django.urls import include, path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("accounts/", include("django.contrib.auth.urls")),
+    path("", include("core.urls")),
+]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/rv_grafica/wsgi.py
+++ b/rv_grafica/wsgi.py
@@ -1,0 +1,10 @@
+"""WSGI config for rv_grafica project."""
+from __future__ import annotations
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "rv_grafica.settings")
+
+application = get_wsgi_application()

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,167 @@
+body {
+  font-family: "Inter", "Segoe UI", Arial, sans-serif;
+  background-color: #f5f6f8;
+  color: #1f2933;
+}
+
+.navbar-brand {
+  letter-spacing: 0.05em;
+}
+
+.card {
+  border-radius: 16px;
+}
+
+.table thead th {
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+}
+
+.status-counter {
+  background-color: #f0f4ff;
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.status-counter.pending {
+  background: linear-gradient(135deg, #f9f6d9, #fffbe6);
+}
+
+.status-counter.in-progress {
+  background: linear-gradient(135deg, #d8f0ff, #e9f6ff);
+}
+
+.status-counter.completed {
+  background: linear-gradient(135deg, #d9f9e2, #ebffef);
+}
+
+.status-counter .count {
+  display: block;
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.status-counter .label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #4d5c6d;
+}
+
+.order-sheet {
+  background: #fff;
+  border-radius: 18px;
+  padding: 2rem;
+  border: 1px solid #e2e8f0;
+}
+
+.order-sheet__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  border-bottom: 2px solid #111827;
+  padding-bottom: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.order-sheet__header h2 {
+  letter-spacing: 0.1em;
+  font-weight: 700;
+}
+
+.order-sheet__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.9rem;
+}
+
+.order-sheet__meta .label {
+  font-weight: 600;
+  color: #4b5563;
+  margin-right: 0.5rem;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.order-sheet__meta .value {
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.order-sheet__info p {
+  margin-bottom: 0.2rem;
+}
+
+.order-sheet__table table {
+  border-color: #cbd5e1;
+}
+
+.order-sheet__table th,
+.order-sheet__table td {
+  vertical-align: middle;
+}
+
+.order-sheet__table .work-label {
+  font-weight: 600;
+  width: 220px;
+}
+
+.order-sheet input[type="text"],
+.order-sheet input[type="email"],
+.order-sheet input[type="number"],
+.order-sheet input[type="date"],
+.order-sheet textarea,
+.order-sheet select {
+  border-radius: 8px;
+}
+
+.order-sheet__table input,
+.order-sheet__table select {
+  font-size: 0.9rem;
+}
+
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.photo-card {
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 0.75rem;
+  border: 1px solid #e2e8f0;
+}
+
+.photo-card img {
+  border-radius: 8px;
+  object-fit: cover;
+  width: 100%;
+  height: 140px;
+}
+
+.table-danger td {
+  background-color: #fef2f2 !important;
+}
+
+@media print {
+  body {
+    background: #fff;
+  }
+
+  header,
+  .btn,
+  .alert,
+  nav,
+  footer,
+  .card > .card-body form {
+    display: none !important;
+  }
+
+  .order-sheet {
+    box-shadow: none !important;
+    border: none;
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,116 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}RV Gráfica{% endblock %}</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
+  </head>
+  <body class="bg-light">
+    <header class="shadow-sm bg-white">
+      <nav class="navbar navbar-expand-lg navbar-light container py-3">
+        <a class="navbar-brand fw-bold text-primary" href="{% if request.user.is_authenticated %}{% url 'dashboard' %}{% else %}{% url 'login' %}{% endif %}">
+          RV Gráfica
+        </a>
+        {% if request.user.is_authenticated %}
+          <button
+            class="navbar-toggler"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#mainNavbar"
+            aria-controls="mainNavbar"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
+          >
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse" id="mainNavbar">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+              <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.url_name in ['order_list', 'order_detail', 'order_create', 'order_update'] %}active{% endif %}" href="{% url 'order_list' %}">
+                  <i class="bi bi-kanban"></i> Órdenes de producción
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.url_name in ['budget_list', 'budget_create', 'budget_update'] %}active{% endif %}" href="{% url 'budget_list' %}">
+                  <i class="bi bi-calculator"></i> Presupuestos
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.url_name in ['invoice_list', 'invoice_create', 'expense_list', 'expense_create'] %}active{% endif %}" href="{% url 'invoice_list' %}">
+                  <i class="bi bi-receipt"></i> Facturación
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.url_name in ['remittance_list', 'remittance_create'] %}active{% endif %}" href="{% url 'remittance_list' %}">
+                  <i class="bi bi-truck"></i> Remitos
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.url_name in ['reports'] %}active{% endif %}" href="{% url 'reports' %}">
+                  <i class="bi bi-graph-up"></i> Reportes
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.url_name in ['finance_movement_list', 'finance_movement_create'] %}active{% endif %}" href="{% url 'finance_movement_list' %}">
+                  <i class="bi bi-cash-stack"></i> Finanzas
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link {% if request.resolver_match.url_name in ['accounting_record_list', 'accounting_record_create'] %}active{% endif %}" href="{% url 'accounting_record_list' %}">
+                  <i class="bi bi-journal-bookmark"></i> Contabilidad
+                </a>
+              </li>
+              <li class="nav-item dropdown">
+                <a
+                  class="nav-link dropdown-toggle {% if request.resolver_match.url_name in ['client_list', 'client_create', 'client_update', 'supplier_list', 'supplier_create', 'supplier_update'] %}active{% endif %}"
+                  href="#"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                >
+                  <i class="bi bi-people"></i> Contactos
+                </a>
+                <ul class="dropdown-menu">
+                  <li><a class="dropdown-item" href="{% url 'client_list' %}">Clientes</a></li>
+                  <li><a class="dropdown-item" href="{% url 'supplier_list' %}">Proveedores</a></li>
+                </ul>
+              </li>
+            </ul>
+            <div class="d-flex align-items-center gap-3">
+              <span class="text-muted small">{{ request.user.get_full_name|default:request.user.username }}</span>
+              <a class="btn btn-outline-secondary btn-sm" href="{% url 'logout' %}">Cerrar sesión</a>
+            </div>
+          </div>
+        {% endif %}
+      </nav>
+    </header>
+
+    <main class="container my-4">
+      {% if messages %}
+        <div class="messages">
+          {% for message in messages %}
+            <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+              {{ message }}
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+      {% block content %}{% endblock %}
+    </main>
+
+    <footer class="text-center py-3 text-muted small">
+      Sistema administrativo RV Gráfica · {% now "Y" %}
+    </footer>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/templates/core/accounting_record_form.html
+++ b/templates/core/accounting_record_form.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block title %}Nuevo registro contable · RV Gráfica{% endblock %}
+{% block content %}
+<h1 class="h4 mb-4">Cargar registro contable</h1>
+<form method="post" class="card shadow-sm border-0 p-4">
+  {% csrf_token %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+  <div class="row g-3">
+    <div class="col-md-4">
+      <label class="form-label">Tipo</label>
+      {{ form.record_type }}
+      {{ form.record_type.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Fecha</label>
+      {{ form.date }}
+      {{ form.date.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Documento</label>
+      {{ form.document_number }}
+      {{ form.document_number.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Cliente</label>
+      {{ form.client }}
+      {{ form.client.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Proveedor</label>
+      {{ form.supplier }}
+      {{ form.supplier.errors }}
+    </div>
+    <div class="col-12">
+      <label class="form-label">Descripción</label>
+      {{ form.description }}
+      {{ form.description.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Debe</label>
+      {{ form.debit }}
+      {{ form.debit.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Haber</label>
+      {{ form.credit }}
+      {{ form.credit.errors }}
+    </div>
+  </div>
+  <div class="text-end mt-4">
+    <a class="btn btn-outline-secondary" href="{% url 'accounting_record_list' %}">Cancelar</a>
+    <button class="btn btn-primary" type="submit">Guardar</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/core/accounting_record_list.html
+++ b/templates/core/accounting_record_list.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+{% block title %}Contabilidad · RV Gráfica{% endblock %}
+{% block content %}
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+  <h1 class="h4 mb-0">Contabilidad</h1>
+  <a class="btn btn-primary" href="{% url 'accounting_record_create' %}"><i class="bi bi-plus-lg"></i> Nuevo registro</a>
+</div>
+<form class="row g-2 mb-4" method="get">
+  <div class="col-sm-3">
+    <select name="tipo" class="form-select">
+      <option value="">Todos los tipos</option>
+      {% for value, label in view.model.TYPE_CHOICES %}
+        <option value="{{ value }}" {% if request.GET.tipo == value %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-sm-3">
+    <input type="date" name="desde" class="form-control" value="{{ request.GET.desde }}" placeholder="Desde" />
+  </div>
+  <div class="col-sm-3">
+    <input type="date" name="hasta" class="form-control" value="{{ request.GET.hasta }}" placeholder="Hasta" />
+  </div>
+  <div class="col-sm-2">
+    <button class="btn btn-outline-secondary w-100" type="submit">Filtrar</button>
+  </div>
+</form>
+<div class="card shadow-sm border-0">
+  <div class="table-responsive">
+    <table class="table align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Fecha</th>
+          <th>Tipo</th>
+          <th>Descripción</th>
+          <th>Documento</th>
+          <th>Cliente</th>
+          <th>Proveedor</th>
+          <th class="text-end">Debe</th>
+          <th class="text-end">Haber</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for record in object_list %}
+          <tr>
+            <td>{{ record.date|date:"d/m/Y" }}</td>
+            <td>{{ record.get_record_type_display }}</td>
+            <td>{{ record.description }}</td>
+            <td>{{ record.document_number|default:"—" }}</td>
+            <td>{{ record.client|default:"—" }}</td>
+            <td>{{ record.supplier|default:"—" }}</td>
+            <td class="text-end">${{ record.debit|floatformat:2 }}</td>
+            <td class="text-end">${{ record.credit|floatformat:2 }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="8" class="text-center py-4 text-muted">No hay registros contables.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% if is_paginated %}
+    <div class="card-footer bg-white">
+      <nav>
+        <ul class="pagination justify-content-end mb-0">
+          {% if page_obj.has_previous %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if request.GET.tipo %}&amp;tipo={{ request.GET.tipo }}{% endif %}{% if request.GET.desde %}&amp;desde={{ request.GET.desde }}{% endif %}{% if request.GET.hasta %}&amp;hasta={{ request.GET.hasta }}{% endif %}">Anterior</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Anterior</span></li>
+          {% endif %}
+          <li class="page-item active"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>
+          {% if page_obj.has_next %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}{% if request.GET.tipo %}&amp;tipo={{ request.GET.tipo }}{% endif %}{% if request.GET.desde %}&amp;desde={{ request.GET.desde }}{% endif %}{% if request.GET.hasta %}&amp;hasta={{ request.GET.hasta }}{% endif %}">Siguiente</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Siguiente</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/core/budget_form.html
+++ b/templates/core/budget_form.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block title %}{% if is_edit %}Editar presupuesto ·{% else %}Nuevo presupuesto ·{% endif %} RV Gráfica{% endblock %}
+{% block content %}
+<h1 class="h4 mb-4">{% if is_edit %}Editar presupuesto{% else %}Nuevo presupuesto{% endif %}</h1>
+<form method="post" class="card shadow-sm border-0 p-4">
+  {% csrf_token %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+  <div class="row g-3">
+    <div class="col-md-6">
+      <label class="form-label">Cliente</label>
+      {{ form.client }}
+      {{ form.client.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Título</label>
+      {{ form.title }}
+      {{ form.title.errors }}
+    </div>
+    <div class="col-12">
+      <label class="form-label">Descripción</label>
+      {{ form.description }}
+      {{ form.description.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Fecha</label>
+      {{ form.date }}
+      {{ form.date.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Metros cuadrados</label>
+      {{ form.square_meters }}
+      {{ form.square_meters.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Precio por m²</label>
+      {{ form.price_per_square_meter }}
+      {{ form.price_per_square_meter.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Costos adicionales</label>
+      {{ form.additional_costs }}
+      {{ form.additional_costs.errors }}
+    </div>
+  </div>
+  <div class="text-end mt-4">
+    <a class="btn btn-outline-secondary" href="{% url 'budget_list' %}">Cancelar</a>
+    <button class="btn btn-primary" type="submit">Guardar</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/core/budget_list.html
+++ b/templates/core/budget_list.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block title %}Presupuestos · RV Gráfica{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h4 mb-0">Presupuestos</h1>
+  <a class="btn btn-primary" href="{% url 'budget_create' %}"><i class="bi bi-plus-lg"></i> Nuevo presupuesto</a>
+</div>
+<div class="card shadow-sm border-0">
+  <div class="table-responsive">
+    <table class="table align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Título</th>
+          <th>Cliente</th>
+          <th>Fecha</th>
+          <th class="text-end">Total</th>
+          <th class="text-end">Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for budget in object_list %}
+          <tr>
+            <td class="fw-semibold">{{ budget.title }}</td>
+            <td>{{ budget.client|default:"—" }}</td>
+            <td>{{ budget.date|date:"d/m/Y" }}</td>
+            <td class="text-end">${{ budget.total_amount|floatformat:2 }}</td>
+            <td class="text-end">
+              <a class="btn btn-sm btn-outline-secondary" href="{% url 'budget_update' budget.pk %}">Editar</a>
+            </td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="5" class="text-center py-4 text-muted">No hay presupuestos cargados.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% if is_paginated %}
+    <div class="card-footer bg-white">
+      <nav>
+        <ul class="pagination justify-content-end mb-0">
+          {% if page_obj.has_previous %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Anterior</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Anterior</span></li>
+          {% endif %}
+          <li class="page-item active"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>
+          {% if page_obj.has_next %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Siguiente</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Siguiente</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/core/client_form.html
+++ b/templates/core/client_form.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block title %}{% if is_edit %}Editar cliente ·{% else %}Nuevo cliente ·{% endif %} RV Gráfica{% endblock %}
+{% block content %}
+<h1 class="h4 mb-4">{% if is_edit %}Editar cliente{% else %}Nuevo cliente{% endif %}</h1>
+<form method="post" class="card shadow-sm border-0 p-4">
+  {% csrf_token %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+  <div class="row g-3">
+    <div class="col-md-6">
+      <label class="form-label">Nombre</label>
+      {{ form.name }}
+      {{ form.name.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Empresa / Línea</label>
+      {{ form.service_line }}
+      {{ form.service_line.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Contacto</label>
+      {{ form.contact_name }}
+      {{ form.contact_name.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Teléfono</label>
+      {{ form.phone }}
+      {{ form.phone.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Mail</label>
+      {{ form.email }}
+      {{ form.email.errors }}
+    </div>
+    <div class="col-12">
+      <label class="form-label">Notas</label>
+      {{ form.notes }}
+      {{ form.notes.errors }}
+    </div>
+  </div>
+  <div class="text-end mt-4">
+    <a class="btn btn-outline-secondary" href="{% url 'client_list' %}">Cancelar</a>
+    <button class="btn btn-primary" type="submit">Guardar</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/core/client_list.html
+++ b/templates/core/client_list.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block title %}Clientes · RV Gráfica{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h4 mb-0">Clientes</h1>
+  <a class="btn btn-primary" href="{% url 'client_create' %}"><i class="bi bi-plus-lg"></i> Nuevo cliente</a>
+</div>
+<div class="card shadow-sm border-0">
+  <div class="table-responsive">
+    <table class="table align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Nombre</th>
+          <th>Empresa / Línea</th>
+          <th>Contacto</th>
+          <th>Teléfono</th>
+          <th>Mail</th>
+          <th class="text-end">Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for client in object_list %}
+          <tr>
+            <td class="fw-semibold">{{ client.name }}</td>
+            <td>{{ client.service_line|default:"—" }}</td>
+            <td>{{ client.contact_name|default:"—" }}</td>
+            <td>{{ client.phone|default:"—" }}</td>
+            <td>{{ client.email|default:"—" }}</td>
+            <td class="text-end">
+              <a class="btn btn-sm btn-outline-secondary" href="{% url 'client_update' client.pk %}">Editar</a>
+            </td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="6" class="text-center py-4 text-muted">No hay clientes cargados.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% if is_paginated %}
+    <div class="card-footer bg-white">
+      <nav>
+        <ul class="pagination justify-content-end mb-0">
+          {% if page_obj.has_previous %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Anterior</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Anterior</span></li>
+          {% endif %}
+          <li class="page-item active"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>
+          {% if page_obj.has_next %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Siguiente</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Siguiente</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/core/dashboard.html
+++ b/templates/core/dashboard.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% block title %}Panel principal · RV Gráfica{% endblock %}
+{% block content %}
+<div class="row g-4">
+  <div class="col-12 col-lg-8">
+    <div class="card shadow-sm border-0 h-100">
+      <div class="card-body">
+        <h2 class="card-title h5 mb-4">Resumen de producción</h2>
+        <div class="row text-center g-3">
+          <div class="col-4">
+            <div class="status-counter pending">
+              <span class="count">{{ pending_orders }}</span>
+              <span class="label">Pendientes</span>
+            </div>
+          </div>
+          <div class="col-4">
+            <div class="status-counter in-progress">
+              <span class="count">{{ in_progress_orders }}</span>
+              <span class="label">En curso</span>
+            </div>
+          </div>
+          <div class="col-4">
+            <div class="status-counter completed">
+              <span class="count">{{ completed_orders }}</span>
+              <span class="label">Finalizadas</span>
+            </div>
+          </div>
+        </div>
+        {% if can_manage_orders %}
+          <div class="mt-4 text-end">
+            <a class="btn btn-primary" href="{% url 'order_create' %}">Crear nueva orden</a>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="col-12 col-lg-4">
+    <div class="card shadow-sm border-0 h-100">
+      <div class="card-body">
+        <h2 class="card-title h5 mb-4">Finanzas</h2>
+        <p class="mb-2"><i class="bi bi-calculator"></i> Presupuestos generados: <strong>{{ budgets_count }}</strong></p>
+        <p class="mb-2"><i class="bi bi-arrow-up-right-circle"></i> Facturas de venta: <strong>{{ sales_invoices }}</strong></p>
+        <p class="mb-2"><i class="bi bi-arrow-down-right-circle"></i> Facturas de compra: <strong>{{ purchase_invoices }}</strong></p>
+        <p class="mb-0"><i class="bi bi-cash-coin"></i> Gastos registrados: <strong>${{ expense_total|floatformat:2 }}</strong></p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/core/expense_form.html
+++ b/templates/core/expense_form.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block title %}Registrar gasto · RV Gráfica{% endblock %}
+{% block content %}
+<h1 class="h4 mb-4">Registrar gasto</h1>
+<form method="post" class="card shadow-sm border-0 p-4">
+  {% csrf_token %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+  <div class="row g-3">
+    <div class="col-md-4">
+      <label class="form-label">Categoría</label>
+      {{ form.category }}
+      {{ form.category.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Fecha</label>
+      {{ form.date }}
+      {{ form.date.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Monto</label>
+      {{ form.amount }}
+      {{ form.amount.errors }}
+    </div>
+    <div class="col-12">
+      <label class="form-label">Descripción</label>
+      {{ form.description }}
+      {{ form.description.errors }}
+    </div>
+  </div>
+  <div class="text-end mt-4">
+    <a class="btn btn-outline-secondary" href="{% url 'expense_list' %}">Cancelar</a>
+    <button class="btn btn-primary" type="submit">Guardar</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/core/expense_list.html
+++ b/templates/core/expense_list.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% block title %}Gastos · RV Gráfica{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h4 mb-0">Planilla de gastos</h1>
+  <a class="btn btn-primary" href="{% url 'expense_create' %}"><i class="bi bi-plus-lg"></i> Registrar gasto</a>
+</div>
+<div class="card shadow-sm border-0">
+  <div class="table-responsive">
+    <table class="table align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Categoría</th>
+          <th>Descripción</th>
+          <th>Fecha</th>
+          <th class="text-end">Monto</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for expense in object_list %}
+          <tr>
+            <td class="fw-semibold">{{ expense.category }}</td>
+            <td>{{ expense.description|default:"—" }}</td>
+            <td>{{ expense.date|date:"d/m/Y" }}</td>
+            <td class="text-end">${{ expense.amount|floatformat:2 }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="4" class="text-center py-4 text-muted">Todavía no registraste gastos.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% if is_paginated %}
+    <div class="card-footer bg-white">
+      <nav>
+        <ul class="pagination justify-content-end mb-0">
+          {% if page_obj.has_previous %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Anterior</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Anterior</span></li>
+          {% endif %}
+          <li class="page-item active"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>
+          {% if page_obj.has_next %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Siguiente</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Siguiente</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/core/finance_movement_form.html
+++ b/templates/core/finance_movement_form.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block title %}Nuevo movimiento financiero · RV Gráfica{% endblock %}
+{% block content %}
+<h1 class="h4 mb-4">Registrar movimiento de cuenta corriente</h1>
+<form method="post" class="card shadow-sm border-0 p-4">
+  {% csrf_token %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+  <div class="row g-3">
+    <div class="col-md-4">
+      <label class="form-label">Tipo</label>
+      {{ form.movement_type }}
+      {{ form.movement_type.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Fecha</label>
+      {{ form.date }}
+      {{ form.date.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Importe</label>
+      {{ form.amount }}
+      {{ form.amount.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Cliente</label>
+      {{ form.client }}
+      {{ form.client.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Proveedor</label>
+      {{ form.supplier }}
+      {{ form.supplier.errors }}
+    </div>
+    <div class="col-12">
+      <label class="form-label">Concepto</label>
+      {{ form.concept }}
+      {{ form.concept.errors }}
+    </div>
+  </div>
+  <div class="text-end mt-4">
+    <a class="btn btn-outline-secondary" href="{% url 'finance_movement_list' %}">Cancelar</a>
+    <button class="btn btn-primary" type="submit">Guardar</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/core/finance_movement_list.html
+++ b/templates/core/finance_movement_list.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+{% block title %}Finanzas · RV Gráfica{% endblock %}
+{% block content %}
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+  <h1 class="h4 mb-0">Finanzas</h1>
+  <a class="btn btn-primary" href="{% url 'finance_movement_create' %}"><i class="bi bi-plus-lg"></i> Nuevo movimiento</a>
+</div>
+<form class="row g-2 mb-4" method="get">
+  <div class="col-sm-3">
+    <select name="tipo" class="form-select">
+      <option value="">Todos los movimientos</option>
+      {% for value, label in view.model.TYPE_CHOICES %}
+        <option value="{{ value }}" {% if request.GET.tipo == value %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-sm-2">
+    <button class="btn btn-outline-secondary w-100" type="submit">Filtrar</button>
+  </div>
+</form>
+<div class="card shadow-sm border-0">
+  <div class="table-responsive">
+    <table class="table align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Fecha</th>
+          <th>Tipo</th>
+          <th>Cliente</th>
+          <th>Proveedor</th>
+          <th>Concepto</th>
+          <th class="text-end">Importe</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for movement in object_list %}
+          <tr>
+            <td>{{ movement.date|date:"d/m/Y" }}</td>
+            <td>{{ movement.get_movement_type_display }}</td>
+            <td>{{ movement.client|default:"—" }}</td>
+            <td>{{ movement.supplier|default:"—" }}</td>
+            <td>{{ movement.concept }}</td>
+            <td class="text-end">${{ movement.amount|floatformat:2 }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="6" class="text-center py-4 text-muted">No hay movimientos registrados.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% if is_paginated %}
+    <div class="card-footer bg-white">
+      <nav>
+        <ul class="pagination justify-content-end mb-0">
+          {% if page_obj.has_previous %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if request.GET.tipo %}&amp;tipo={{ request.GET.tipo }}{% endif %}">Anterior</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Anterior</span></li>
+          {% endif %}
+          <li class="page-item active"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>
+          {% if page_obj.has_next %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}{% if request.GET.tipo %}&amp;tipo={{ request.GET.tipo }}{% endif %}">Siguiente</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Siguiente</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/core/invoice_form.html
+++ b/templates/core/invoice_form.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+{% block title %}Nueva factura · RV Gráfica{% endblock %}
+{% block content %}
+<h1 class="h4 mb-4">Cargar factura</h1>
+<form method="post" class="card shadow-sm border-0 p-4">
+  {% csrf_token %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+  <div class="row g-3">
+    <div class="col-md-4">
+      <label class="form-label">Tipo</label>
+      {{ form.invoice_type }}
+      {{ form.invoice_type.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Número</label>
+      {{ form.number }}
+      {{ form.number.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Fecha</label>
+      {{ form.date }}
+      {{ form.date.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Cliente</label>
+      {{ form.client }}
+      {{ form.client.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Proveedor</label>
+      {{ form.supplier }}
+      {{ form.supplier.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Orden relacionada</label>
+      {{ form.order }}
+      {{ form.order.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Importe neto</label>
+      {{ form.gross_amount }}
+      {{ form.gross_amount.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Alícuota de IVA</label>
+      {{ form.iva_rate }}
+      {{ form.iva_rate.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">IVA calculado</label>
+      {{ form.iva_amount }}
+      {{ form.iva_amount.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Percepciones</label>
+      {{ form.additional_tax_type }}
+      {{ form.additional_tax_type.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Importe percepciones</label>
+      {{ form.additional_tax_amount }}
+      {{ form.additional_tax_amount.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Total factura</label>
+      {{ form.amount }}
+      {{ form.amount.errors }}
+    </div>
+    <div class="col-12">
+      <label class="form-label">Descripción</label>
+      {{ form.description }}
+      {{ form.description.errors }}
+    </div>
+  </div>
+  <div class="text-end mt-4">
+    <a class="btn btn-outline-secondary" href="{% url 'invoice_list' %}">Cancelar</a>
+    <button class="btn btn-primary" type="submit">Guardar</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/core/invoice_list.html
+++ b/templates/core/invoice_list.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+{% block title %}Facturación · RV Gráfica{% endblock %}
+{% block content %}
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+  <h1 class="h4 mb-0">Facturación</h1>
+  <div class="d-flex gap-2">
+    <a class="btn btn-outline-secondary" href="{% url 'remittance_list' %}"><i class="bi bi-truck"></i> Remitos</a>
+    <a class="btn btn-primary" href="{% url 'invoice_create' %}"><i class="bi bi-plus-lg"></i> Nueva factura</a>
+  </div>
+</div>
+<form class="row g-2 mb-4" method="get">
+  <div class="col-sm-4">
+    <select name="tipo" class="form-select">
+      <option value="">Todos los tipos</option>
+      {% for value, label in view.model.TYPE_CHOICES %}
+        <option value="{{ value }}" {% if request.GET.tipo == value %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-sm-2">
+    <button class="btn btn-outline-secondary w-100" type="submit">Filtrar</button>
+  </div>
+</form>
+<div class="card shadow-sm border-0">
+  <div class="table-responsive">
+    <table class="table align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Número</th>
+          <th>Tipo</th>
+          <th>Cliente / Proveedor</th>
+          <th>Orden relacionada</th>
+          <th>Fecha</th>
+          <th class="text-end">Importe neto</th>
+          <th class="text-end">IVA</th>
+          <th class="text-end">Percepciones</th>
+          <th class="text-end">Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for invoice in object_list %}
+          <tr>
+            <td class="fw-semibold">{{ invoice.number }}</td>
+            <td>{{ invoice.get_invoice_type_display }}</td>
+            <td>
+              {% if invoice.invoice_type == invoice.TYPE_SALE %}
+                {{ invoice.client|default:"—" }}
+              {% else %}
+                {{ invoice.supplier|default:"—" }}
+              {% endif %}
+            </td>
+            <td>{% if invoice.order %}#{{ invoice.order.order_number }}{% else %}—{% endif %}</td>
+            <td>{{ invoice.date|date:"d/m/Y" }}</td>
+            <td class="text-end">${{ invoice.gross_amount|floatformat:2 }}</td>
+            <td class="text-end">${{ invoice.iva_amount|floatformat:2 }}</td>
+            <td class="text-end">${{ invoice.additional_tax_amount|floatformat:2 }}</td>
+            <td class="text-end">${{ invoice.amount|floatformat:2 }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="9" class="text-center py-4 text-muted">No hay facturas cargadas.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% if is_paginated %}
+    <div class="card-footer bg-white">
+      <nav>
+        <ul class="pagination justify-content-end mb-0">
+          {% if page_obj.has_previous %}
+            <li class="page-item"><a class="page-link" href="?{% if request.GET.tipo %}tipo={{ request.GET.tipo }}&amp;{% endif %}page={{ page_obj.previous_page_number }}">Anterior</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Anterior</span></li>
+          {% endif %}
+          <li class="page-item active"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>
+          {% if page_obj.has_next %}
+            <li class="page-item"><a class="page-link" href="?{% if request.GET.tipo %}tipo={{ request.GET.tipo }}&amp;{% endif %}page={{ page_obj.next_page_number }}">Siguiente</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Siguiente</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+  {% endif %}
+</div>
+<div class="mt-4">
+  <a class="btn btn-outline-secondary" href="{% url 'expense_list' %}"><i class="bi bi-wallet2"></i> Ver planilla de gastos</a>
+</div>
+{% endblock %}

--- a/templates/core/order_detail.html
+++ b/templates/core/order_detail.html
@@ -1,0 +1,162 @@
+{% extends "base.html" %}
+{% block title %}Orden {{ object.order_number }} · RV Gráfica{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h4 mb-0">Orden de producción #{{ object.order_number }}</h1>
+  <div class="d-flex gap-2">
+    <button class="btn btn-outline-secondary" onclick="window.print(); return false;">
+      <i class="bi bi-printer"></i> Imprimir / PDF
+    </button>
+    {% if can_edit %}
+      <a class="btn btn-primary" href="{% url 'order_update' object.pk %}"><i class="bi bi-pencil"></i> Editar</a>
+    {% endif %}
+  </div>
+</div>
+<div class="order-sheet shadow-sm">
+  <div class="order-sheet__header">
+    <div>
+      <h2 class="mb-1">ORDEN DE PEDIDO</h2>
+      <p class="mb-0">Gráfica RV · Autoadhesiva y cartelería</p>
+    </div>
+    <div class="order-sheet__meta">
+      <div><span class="label">N°</span> <span class="value">{{ object.order_number }}</span></div>
+      <div class="text-end">
+        <span class="label">Fecha</span>
+        <span class="value">{{ object.order_date|date:"d/m/Y" }}</span>
+      </div>
+    </div>
+  </div>
+  <div class="order-sheet__info">
+    <div class="row g-3">
+      <div class="col-md-4">
+        <p class="text-muted mb-1">Cliente</p>
+        <p class="fw-semibold mb-0">{% if object.client %}{{ object.client.name }}{% else %}—{% endif %}</p>
+      </div>
+      <div class="col-md-4">
+        <p class="text-muted mb-1">Empresa / Línea</p>
+        <p class="mb-0">{{ object.service_line|default:"—" }}</p>
+      </div>
+      <div class="col-md-4">
+        <p class="text-muted mb-1">Estado</p>
+        {% if object.status == object.STATUS_PENDING %}
+          <span class="badge bg-warning text-dark">Pendiente</span>
+        {% elif object.status == object.STATUS_IN_PROGRESS %}
+          <span class="badge bg-info text-dark">En curso</span>
+        {% else %}
+          <span class="badge bg-success">Finalizada</span>
+        {% endif %}
+      </div>
+      <div class="col-md-4">
+        <p class="text-muted mb-1">Interno</p>
+        <p class="mb-0">{{ object.internal_code|default:"—" }}</p>
+      </div>
+      <div class="col-md-4">
+        <p class="text-muted mb-1">Carrocería</p>
+        <p class="mb-0">{{ object.bodywork|default:"—" }}</p>
+      </div>
+      <div class="col-md-4">
+        <p class="text-muted mb-1">Contacto</p>
+        <p class="mb-0">{{ object.contact_name|default:"—" }}</p>
+      </div>
+      <div class="col-md-4">
+        <p class="text-muted mb-1">Mail</p>
+        <p class="mb-0">{{ object.email|default:"—" }}</p>
+      </div>
+      <div class="col-md-4">
+        <p class="text-muted mb-1">Teléfono</p>
+        <p class="mb-0">{{ object.phone|default:"—" }}</p>
+      </div>
+      <div class="col-12">
+        <p class="text-muted mb-1">Observaciones</p>
+        <p class="mb-0">{{ object.notes|default:"—" }}</p>
+      </div>
+    </div>
+  </div>
+  <div class="order-sheet__table table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Descripción del trabajo</th>
+          <th>Detalle</th>
+          <th>Colores</th>
+          <th>Medida</th>
+          <th>Cant.</th>
+          <th>Precio</th>
+          <th>Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in items %}
+          <tr>
+            <td class="work-label">{{ item.custom_description|default:item.get_preset_label_display }}</td>
+            <td>{{ item.detail|default:"" }}</td>
+            <td>{{ item.colors|default:"" }}</td>
+            <td>{{ item.measure|default:"" }}</td>
+            <td class="w-10">{{ item.quantity|default:"" }}</td>
+            <td class="w-10">{{ item.unit_price|default:"" }}</td>
+            <td class="w-10">{{ item.total_amount|default:"" }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+<div class="mt-4 row g-4">
+  <div class="col-lg-6">
+    <div class="card shadow-sm border-0 h-100">
+      <div class="card-body">
+        <h2 class="h5 mb-3">Registro fotográfico</h2>
+        {% if can_upload %}
+          <form method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            {% if photo_form.non_field_errors %}
+              <div class="alert alert-danger">{{ photo_form.non_field_errors }}</div>
+            {% endif %}
+            <div class="mb-3">
+              <label class="form-label">Foto</label>
+              {{ photo_form.image }}
+              {{ photo_form.image.errors }}
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Descripción</label>
+              {{ photo_form.description }}
+              {{ photo_form.description.errors }}
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Materiales utilizados</label>
+              {{ photo_form.materials }}
+              {{ photo_form.materials.errors }}
+            </div>
+            <button class="btn btn-primary" type="submit">Subir foto</button>
+          </form>
+        {% else %}
+          <p class="text-muted">No tenés permisos para subir imágenes.</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-6">
+    <div class="card shadow-sm border-0 h-100">
+      <div class="card-body">
+        <h2 class="h5 mb-3">Fotos cargadas</h2>
+        {% if photos %}
+          <div class="photo-grid">
+            {% for photo in photos %}
+              <div class="photo-card">
+                <img src="{{ photo.image.url }}" alt="Foto orden {{ object.order_number }}" class="img-fluid rounded mb-2" />
+                {% if photo.description %}<p class="small mb-1">{{ photo.description }}</p>{% endif %}
+                {% if photo.materials.all %}
+                  <p class="small text-muted mb-1">Materiales: {{ photo.materials.all|join:", " }}</p>
+                {% endif %}
+                <p class="small text-muted mb-0">Subido por {{ photo.uploaded_by|default:"Equipo RV" }} el {{ photo.created_at|date:"d/m/Y H:i" }}</p>
+              </div>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="text-muted mb-0">Aún no se cargaron fotos para esta orden.</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/core/order_form.html
+++ b/templates/core/order_form.html
@@ -1,0 +1,132 @@
+{% extends "base.html" %}
+{% block title %}{% if is_edit %}Editar orden ·{% else %}Nueva orden ·{% endif %} RV Gráfica{% endblock %}
+{% block content %}
+<h1 class="h4 mb-4">{% if is_edit %}Editar orden de producción{% else %}Nueva orden de producción{% endif %}</h1>
+<form method="post" novalidate>
+  {% csrf_token %}
+  {{ formset.management_form }}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+  <div class="order-sheet shadow-sm">
+    <div class="order-sheet__header">
+      <div>
+        <h2 class="mb-1">ORDEN DE PEDIDO</h2>
+        <p class="mb-0">Gráfica RV · Autoadhesiva y cartelería</p>
+      </div>
+      <div class="order-sheet__meta">
+        <div><span class="label">N°</span> <span class="value">{% if is_edit %}{{ order.order_number }}{% else %}—{% endif %}</span></div>
+        <div class="text-end">
+          <label class="label" for="id_order_date">Fecha</label>
+          {{ form.order_date }}
+          {{ form.order_date.errors }}
+        </div>
+      </div>
+    </div>
+    <div class="order-sheet__info">
+      <div class="row g-3">
+        <div class="col-md-6">
+          <label class="form-label">Cliente</label>
+          {{ form.client }}
+          {{ form.client.errors }}
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">Estado</label>
+          {% if is_edit %}
+            {{ form.status }}
+          {% else %}
+            <input class="form-control" value="Pendiente" disabled />
+            <input type="hidden" name="status" value="{{ default_status }}" />
+          {% endif %}
+          {{ form.status.errors }}
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Empresa / Línea</label>
+          {{ form.service_line }}
+          {{ form.service_line.errors }}
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Interno</label>
+          {{ form.internal_code }}
+          {{ form.internal_code.errors }}
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Carrocería</label>
+          {{ form.bodywork }}
+          {{ form.bodywork.errors }}
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Nombre y apellido</label>
+          {{ form.contact_name }}
+          {{ form.contact_name.errors }}
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Mail</label>
+          {{ form.email }}
+          {{ form.email.errors }}
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">Teléfono</label>
+          {{ form.phone }}
+          {{ form.phone.errors }}
+        </div>
+        <div class="col-12">
+          <label class="form-label">Observaciones</label>
+          {{ form.notes }}
+          {{ form.notes.errors }}
+        </div>
+      </div>
+    </div>
+    <div class="order-sheet__table table-responsive">
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Descripción del trabajo</th>
+            <th>Detalle</th>
+            <th>Colores</th>
+            <th>Medida</th>
+            <th>Cant.</th>
+            <th>Precio</th>
+            <th>Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if formset.non_form_errors %}
+            <tr>
+              <td colspan="7" class="text-danger">{{ formset.non_form_errors }}</td>
+            </tr>
+          {% endif %}
+          {% for item_form in formset %}
+            <tr>
+              <td class="work-label">
+                {{ item_form.preset_key }}
+                {{ item_form.preset_name }}
+                {{ item_form.preset_name.errors }}
+              </td>
+              <td>{{ item_form.detail }}</td>
+              <td>{{ item_form.colors }}</td>
+              <td>{{ item_form.measure }}</td>
+              <td class="w-10">{{ item_form.quantity }}</td>
+              <td class="w-10">{{ item_form.unit_price }}</td>
+              <td class="w-10">{{ item_form.total_amount }}</td>
+            </tr>
+            {% if item_form.errors %}
+              <tr class="table-danger">
+                <td colspan="7">
+                  {% for field, error_list in item_form.errors.items %}
+                    <div>{{ error_list|join:", " }}</div>
+                  {% endfor %}
+                </td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="text-end mt-4">
+    <a class="btn btn-outline-secondary" href="{% if is_edit %}{% url 'order_detail' order.pk %}{% else %}{% url 'order_list' %}{% endif %}">Cancelar</a>
+    <button class="btn btn-primary" type="submit">Guardar</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/core/order_list.html
+++ b/templates/core/order_list.html
@@ -1,0 +1,88 @@
+{% extends "base.html" %}
+{% block title %}Órdenes de producción · RV Gráfica{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h4 mb-0">Órdenes de producción</h1>
+  {% if can_manage_orders %}
+    <a class="btn btn-primary" href="{% url 'order_create' %}"><i class="bi bi-plus-lg"></i> Nueva orden</a>
+  {% endif %}
+</div>
+<form class="row g-2 mb-4" method="get">
+  <div class="col-sm-6 col-lg-4">
+    <input type="search" class="form-control" name="q" placeholder="Buscar por cliente u orden" value="{{ search }}" />
+  </div>
+  <div class="col-sm-4 col-lg-3">
+    <select name="estado" class="form-select">
+      <option value="">Todos los estados</option>
+      {% for value, label in view.model.STATUS_CHOICES %}
+        <option value="{{ value }}" {% if status == value %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-sm-2 col-lg-2">
+    <button class="btn btn-outline-secondary w-100" type="submit">Filtrar</button>
+  </div>
+</form>
+<div class="card shadow-sm border-0">
+  <div class="table-responsive">
+    <table class="table align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>N°</th>
+          <th>Cliente</th>
+          <th>Fecha</th>
+          <th>Estado</th>
+          <th class="text-end">Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for order in object_list %}
+          <tr>
+            <td class="fw-semibold">{{ order.order_number }}</td>
+            <td>{% if order.client %}{{ order.client.name }}{% else %}—{% endif %}</td>
+            <td>{{ order.order_date|date:"d/m/Y" }}</td>
+            <td>
+              {% if order.status == order.STATUS_PENDING %}
+                <span class="badge bg-warning text-dark">Pendiente</span>
+              {% elif order.status == order.STATUS_IN_PROGRESS %}
+                <span class="badge bg-info text-dark">En curso</span>
+              {% else %}
+                <span class="badge bg-success">Finalizada</span>
+              {% endif %}
+            </td>
+            <td class="text-end">
+              <a class="btn btn-sm btn-outline-primary" href="{% url 'order_detail' order.pk %}">Ver</a>
+              {% if can_manage_orders %}
+                <a class="btn btn-sm btn-outline-secondary" href="{% url 'order_update' order.pk %}">Editar</a>
+              {% endif %}
+            </td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="5" class="text-center py-4 text-muted">No hay órdenes registradas.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% if is_paginated %}
+    <div class="card-footer bg-white">
+      <nav>
+        <ul class="pagination justify-content-end mb-0">
+          {% if page_obj.has_previous %}
+            <li class="page-item"><a class="page-link" href="?{% if status %}estado={{ status }}&amp;{% endif %}{% if search %}q={{ search }}&amp;{% endif %}page={{ page_obj.previous_page_number }}">Anterior</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Anterior</span></li>
+          {% endif %}
+          <li class="page-item active"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>
+          {% if page_obj.has_next %}
+            <li class="page-item"><a class="page-link" href="?{% if status %}estado={{ status }}&amp;{% endif %}{% if search %}q={{ search }}&amp;{% endif %}page={{ page_obj.next_page_number }}">Siguiente</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Siguiente</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/core/remittance_form.html
+++ b/templates/core/remittance_form.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Nuevo remito · RV Gráfica{% endblock %}
+{% block content %}
+<h1 class="h4 mb-4">Cargar remito</h1>
+<form method="post" class="card shadow-sm border-0 p-4">
+  {% csrf_token %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+  <div class="row g-3">
+    <div class="col-md-4">
+      <label class="form-label">Número</label>
+      {{ form.number }}
+      {{ form.number.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Fecha</label>
+      {{ form.date }}
+      {{ form.date.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Orden relacionada</label>
+      {{ form.order }}
+      {{ form.order.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Cliente</label>
+      {{ form.client }}
+      {{ form.client.errors }}
+    </div>
+    <div class="col-12">
+      <label class="form-label">Descripción</label>
+      {{ form.description }}
+      {{ form.description.errors }}
+    </div>
+  </div>
+  <div class="text-end mt-4">
+    <a class="btn btn-outline-secondary" href="{% url 'remittance_list' %}">Cancelar</a>
+    <button class="btn btn-primary" type="submit">Guardar</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/core/remittance_list.html
+++ b/templates/core/remittance_list.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block title %}Remitos · RV Gráfica{% endblock %}
+{% block content %}
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+  <h1 class="h4 mb-0">Remitos</h1>
+  <a class="btn btn-primary" href="{% url 'remittance_create' %}"><i class="bi bi-plus-lg"></i> Nuevo remito</a>
+</div>
+<div class="card shadow-sm border-0">
+  <div class="table-responsive">
+    <table class="table align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Número</th>
+          <th>Fecha</th>
+          <th>Cliente</th>
+          <th>Orden</th>
+          <th>Descripción</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for remittance in object_list %}
+          <tr>
+            <td class="fw-semibold">{{ remittance.number }}</td>
+            <td>{{ remittance.date|date:"d/m/Y" }}</td>
+            <td>{{ remittance.client|default:"—" }}</td>
+            <td>{% if remittance.order %}#{{ remittance.order.order_number }}{% else %}—{% endif %}</td>
+            <td>{{ remittance.description|default:"—" }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="5" class="text-center py-4 text-muted">No hay remitos cargados.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% if is_paginated %}
+    <div class="card-footer bg-white">
+      <nav>
+        <ul class="pagination justify-content-end mb-0">
+          {% if page_obj.has_previous %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Anterior</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Anterior</span></li>
+          {% endif %}
+          <li class="page-item active"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>
+          {% if page_obj.has_next %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Siguiente</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Siguiente</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/core/reports.html
+++ b/templates/core/reports.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% block title %}Reportes · RV Gráfica{% endblock %}
+{% block content %}
+<h1 class="h4 mb-4">Reportes</h1>
+<form method="get" class="card shadow-sm border-0 p-4 mb-4">
+  <div class="row g-3">
+    <div class="col-md-4">
+      <label class="form-label">Tipo de reporte</label>
+      {{ form.report_type }}
+      {{ form.report_type.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Cliente</label>
+      {{ form.client }}
+      {{ form.client.errors }}
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">Proveedor</label>
+      {{ form.supplier }}
+      {{ form.supplier.errors }}
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Desde</label>
+      {{ form.date_from }}
+      {{ form.date_from.errors }}
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Hasta</label>
+      {{ form.date_to }}
+      {{ form.date_to.errors }}
+    </div>
+  </div>
+  <div class="text-end mt-4">
+    <button class="btn btn-outline-secondary" type="submit">Generar reporte</button>
+  </div>
+</form>
+{% if report.entries %}
+  <div class="card shadow-sm border-0">
+    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+      <h2 class="h6 mb-0">Resultados</h2>
+      <span class="badge bg-primary">Saldo: ${{ report.balance|floatformat:2 }}</span>
+    </div>
+    <div class="table-responsive">
+      <table class="table mb-0 align-middle">
+        <thead class="table-light">
+          <tr>
+            <th>Fecha</th>
+            <th>Concepto</th>
+            <th>Cliente</th>
+            <th>Proveedor</th>
+            <th>Tipo</th>
+            <th class="text-end">Importe</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for entry in report.entries %}
+            <tr>
+              <td>{{ entry.date|date:"d/m/Y" }}</td>
+              <td>{{ entry.concept }}</td>
+              <td>{{ entry.client|default:"—" }}</td>
+              <td>{{ entry.supplier|default:"—" }}</td>
+              <td>{{ entry.movement_type }}</td>
+              <td class="text-end">${{ entry.amount|floatformat:2 }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+{% elif request.GET %}
+  <div class="alert alert-info">No se encontraron movimientos para los filtros seleccionados.</div>
+{% endif %}
+{% endblock %}

--- a/templates/core/supplier_form.html
+++ b/templates/core/supplier_form.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}{% if is_edit %}Editar proveedor ·{% else %}Nuevo proveedor ·{% endif %} RV Gráfica{% endblock %}
+{% block content %}
+<h1 class="h4 mb-4">{% if is_edit %}Editar proveedor{% else %}Nuevo proveedor{% endif %}</h1>
+<form method="post" class="card shadow-sm border-0 p-4">
+  {% csrf_token %}
+  {% if form.non_field_errors %}
+    <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+  {% endif %}
+  <div class="row g-3">
+    <div class="col-md-6">
+      <label class="form-label">Nombre</label>
+      {{ form.name }}
+      {{ form.name.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Contacto</label>
+      {{ form.contact_name }}
+      {{ form.contact_name.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Teléfono</label>
+      {{ form.phone }}
+      {{ form.phone.errors }}
+    </div>
+    <div class="col-md-6">
+      <label class="form-label">Mail</label>
+      {{ form.email }}
+      {{ form.email.errors }}
+    </div>
+    <div class="col-12">
+      <label class="form-label">Notas</label>
+      {{ form.notes }}
+      {{ form.notes.errors }}
+    </div>
+  </div>
+  <div class="text-end mt-4">
+    <a class="btn btn-outline-secondary" href="{% url 'supplier_list' %}">Cancelar</a>
+    <button class="btn btn-primary" type="submit">Guardar</button>
+  </div>
+</form>
+{% endblock %}

--- a/templates/core/supplier_list.html
+++ b/templates/core/supplier_list.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block title %}Proveedores · RV Gráfica{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h4 mb-0">Proveedores</h1>
+  <a class="btn btn-primary" href="{% url 'supplier_create' %}"><i class="bi bi-plus-lg"></i> Nuevo proveedor</a>
+</div>
+<div class="card shadow-sm border-0">
+  <div class="table-responsive">
+    <table class="table align-middle mb-0">
+      <thead class="table-light">
+        <tr>
+          <th>Nombre</th>
+          <th>Contacto</th>
+          <th>Teléfono</th>
+          <th>Mail</th>
+          <th class="text-end">Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for supplier in object_list %}
+          <tr>
+            <td class="fw-semibold">{{ supplier.name }}</td>
+            <td>{{ supplier.contact_name|default:"—" }}</td>
+            <td>{{ supplier.phone|default:"—" }}</td>
+            <td>{{ supplier.email|default:"—" }}</td>
+            <td class="text-end">
+              <a class="btn btn-sm btn-outline-secondary" href="{% url 'supplier_update' supplier.pk %}">Editar</a>
+            </td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="5" class="text-center py-4 text-muted">No hay proveedores cargados.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% if is_paginated %}
+    <div class="card-footer bg-white">
+      <nav>
+        <ul class="pagination justify-content-end mb-0">
+          {% if page_obj.has_previous %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Anterior</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Anterior</span></li>
+          {% endif %}
+          <li class="page-item active"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>
+          {% if page_obj.has_next %}
+            <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Siguiente</a></li>
+          {% else %}
+            <li class="page-item disabled"><span class="page-link">Siguiente</span></li>
+          {% endif %}
+        </ul>
+      </nav>
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Iniciar sesión · RV Gráfica{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-6 col-lg-4">
+    <div class="card shadow-sm border-0 p-4">
+      <h1 class="h4 mb-3 text-center">Ingresar</h1>
+      <form method="post">
+        {% csrf_token %}
+        {% if form.non_field_errors %}
+          <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+        {% endif %}
+        <div class="mb-3">
+          <label class="form-label" for="id_username">Usuario</label>
+          {{ form.username.errors }}
+          <input
+            type="text"
+            name="{{ form.username.name }}"
+            value="{{ form.username.value|default_if_none:'' }}"
+            class="form-control"
+            required
+            autofocus
+            id="id_username"
+          />
+        </div>
+        <div class="mb-3">
+          <label class="form-label" for="id_password">Contraseña</label>
+          {{ form.password.errors }}
+          <input
+            type="password"
+            name="{{ form.password.name }}"
+            class="form-control"
+            required
+            id="id_password"
+          />
+        </div>
+        <button class="btn btn-primary w-100" type="submit">Entrar</button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- extend invoices with IVA and perception fields that auto-calculate totals and mark linked production orders as completed
- add remittance, finance, reporting, and accounting sections with corresponding models, forms, URLs, and responsive templates
- expose the new records through the admin panel and navigation plus a migration to create the required tables

## Testing
- `python manage.py makemigrations core` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19ec2a66c8324a0723ac27df129bf